### PR TITLE
Warn rather than fail when git repository does not exist

### DIFF
--- a/src/integTest/groovy/nebula/plugin/release/ReleasePluginNewProjectIntegrationSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/release/ReleasePluginNewProjectIntegrationSpec.groovy
@@ -1,0 +1,38 @@
+package nebula.plugin.release
+import nebula.test.IntegrationSpec
+import org.ajoberstar.grgit.Grgit
+import org.gradle.api.plugins.JavaPlugin
+/**
+ * Verify the behavior of nebula-release under various states for a new project (e.g. no git repo yet initialized, no
+ * initial commit)
+ */
+class ReleasePluginNewProjectIntegrationSpec extends IntegrationSpec {
+    def 'release tasks unavailable when no git repository has been initialized'() {
+        when:
+        buildFile << """
+            ${applyPlugin(ReleasePlugin)}
+            ${applyPlugin(JavaPlugin)}
+        """
+
+        then:
+        runTasksSuccessfully('build')
+        runTasksWithFailure('snapshot')
+    }
+
+    def 'release tasks unavailable when git repository has no commits'() {
+        setup: // equivalent of having completed `git init` but no initial commit
+        def origin = new File(projectDir.parent, "${projectDir.name}.git")
+        origin.mkdirs()
+        Grgit.init(dir: origin)
+
+        when:
+        buildFile << """
+            ${applyPlugin(ReleasePlugin)}
+            ${applyPlugin(JavaPlugin)}
+        """
+
+        then:
+        runTasksSuccessfully('build')
+        runTasksWithFailure('snapshot')
+    }
+}

--- a/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
@@ -19,6 +19,7 @@ import nebula.core.ProjectType
 import org.ajoberstar.gradle.git.release.base.BaseReleasePlugin
 import org.ajoberstar.gradle.git.release.base.ReleasePluginExtension
 import org.ajoberstar.grgit.Grgit
+import org.eclipse.jgit.errors.RepositoryNotFoundException
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -49,6 +50,14 @@ class ReleasePlugin implements Plugin<Project> {
         this.project = project
 
         ProjectType type = new ProjectType(project)
+
+        try {
+            Grgit.open(dir: project.rootProject.projectDir)
+        }
+        catch(RepositoryNotFoundException e) {
+            logger.warn("This project does not have a fully initialized git repository yet -- nebula-release tasks will not be available")
+            return
+        }
 
         if (type.isRootProject) {
             project.plugins.apply(BaseReleasePlugin)


### PR DESCRIPTION
Also, do not fail when `git init` has been run, but there is no initial commit yet.