### PR TITLE
Tag list match regex

### DIFF
--- a/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
@@ -180,8 +180,8 @@ class ReleasePlugin implements Plugin<Project> {
         }
 
         List<Tag> tags = git.tag.list()
-        if (!tags.any { it.fullName.split('/')[-1] ==~ /v[\d]+.[\d+].[\d]+/ }) {
-            throw new GradleException('The nebula-release-plugin requires a Git tag to indicate initial version. Use "git tag v1.0.0" to start from version 1.0.0.')
+        if (!tags.any { it.fullName.split('/')[-1] ==~ /v[\d]+\.[\d]+\.[\d]+/ }) {
+            throw new GradleException('The nebula.release-plugin requires a Git tag to indicate initial version. Use "git tag v1.0.0" to start from version 1.0.0.')
         }
     }
 


### PR DESCRIPTION
I don't believe the regex used to match tags is going to work. I get this error with the latest version:

    * What went wrong:
    An exception occurred applying plugin request [id: 'nebula.netflixoss', version: '3.1.2']
    > The nebula-release-plugin requires a Git tag to indicate initial version. Use "git tag v1.0.0" to start from version 1.0.0.