### PR TITLE
Added support for including branch name in the version for maven style snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,19 +51,33 @@ All tasks default to bumping the minor version.
 
       void addReleaseBranchPattern(String pattern)
       void addExcludeBranchPattern(String pattern)
+
+      branchNameInSnapshot {
+        boolean enabled = false
+        Set<String> includeBranchPatterns = [/feature(-|\/).*/] as Set
+        Set<String> excludeBranchPatterns = [] as Set
+
+        void addIncludeBranchPattern(String pattern)
+        void addExcludeBranchPattern(String pattern)
+      }
     }
 
-| Property                | Type          | Default                                                                   | Description                                                                                                                                                                                                                                                           |
-| ----------------------- | ------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| releaseBranchPatterns   | `Set<String>` | `[/master/, /HEAD/, /(release(-|\/))?\d+(\.\d+)?\.x/, /v?\d+\.\d+\.\d+/]` | Branch patterns that are acceptable to release from. The default pattern will match things like `master`, `1.2.x`, `release-42.x`, `release/2.x`, `v1.2.3`. If the set is empty releases will be possible from any branch that doesn't match `excludeBranchPatterns`. |
-| excludeBranchPatterns   | `Set<String>` | `[]`                                                                      | Branch patterns that you cannot release from. If a branch matches both `releaseBranchPatterns` and `excludeBranchPatterns` it will be excluded.                                                                                                                       |
-| shortenedBranchPattern  | `String`      | `/(?:feature(?:-|\/))?(.+)/`                                              | Branch `widget1` will append `widget1` to snapshot version numbers, and branch `feature/widget2` will append `widget2` to snapshot version numbers. You may configure this field, the regex is expected to have exactly one capture group.                            |
+| Property                                    | Type                        | Default                                                                   | Description                                                                                                                                                                                                                                                               |
+| ------------------------------------------- | --------------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| releaseBranchPatterns                       | `Set<String>`               | `[/master/, /HEAD/, /(release(-|\/))?\d+(\.\d+)?\.x/, /v?\d+\.\d+\.\d+/]` | Branch patterns that are acceptable to release from. The default pattern will match things like `master`, `1.2.x`, `release-42.x`, `release/2.x`, `v1.2.3`. If the set is empty releases will be possible from any branch that doesn't match `excludeBranchPatterns`.     |
+| excludeBranchPatterns                       | `Set<String>`               | `[]`                                                                      | Branch patterns that you cannot release from. If a branch matches both `releaseBranchPatterns` and `excludeBranchPatterns` it will be excluded.                                                                                                                           |
+| shortenedBranchPattern                      | `String`                    | `/(?:feature(?:-|\/))?(.+)/`                                              | Branch `widget1` will append `widget1` to snapshot version numbers, and branch `feature/widget2` will append `widget2` to snapshot version numbers. You may configure this field, the regex is expected to have exactly one capture group.                                |
+| branchNameInSnapshot.enabled                | `boolean`                   | `false`                                                                   | If enabled, branch `feature/widget` will append `widget2` to maven-style snapshot version numbers, e.g. `0.1.0-widget2-SNAPSHOT`. This will allow concurrent features to be published/consumed from Maven independently. Otherwise all branches will use `0.1.0-SNAPSHOT` |
+| branchNameInSnapshot.includeBranchPatterns  | `Set<String>`               | `[/feature(-|\/).*/]`                                                     | Branch patterns that need the branch name in the version for maven-style snapshots. The default pattern will match feature branches only (the `develop` branch for git-flow users will not use the branch name for maven-style snapshots).                                |
+| branchNameInSnapshot.excludeBranchPatterns  | `Set<String>`               | `[]`                                                                      | Branch patterns that should not have the branch name in the version for maven-style snapshots (overrides patterns defined in `includeBranchPatterns`).                                                                                                                    |
 
 
-| Method                  | Arguments        | Description                                                                                                                               |
-| ----------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| addReleaseBranchPattern | `String pattern` | Calling this method will add a pattern to the set of `releaseBranchPatterns`, usage: `nebulaRelease { addReleaseBranchPattern(/myregex/)` |
-| addExcludeBranchPattern | `String pattern` | Calling this method will add a pattern to the set of `excludeBranchPatterns`, usage: `nebulaRelease { addExcludeBranchPattern(/myregex/)` |
+| Method                                       | Arguments        | Description                                                                                                                                                                           |
+| -------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| addReleaseBranchPattern                      | `String pattern` | Calling this method will add a pattern to the set of `releaseBranchPatterns`, usage: `nebulaRelease { addReleaseBranchPattern(/myregex/)`                                             |
+| addExcludeBranchPattern                      | `String pattern` | Calling this method will add a pattern to the set of `excludeBranchPatterns`, usage: `nebulaRelease { addExcludeBranchPattern(/myregex/)`                                             |
+| branchNameInSnapshot.addIncludeBranchPattern | `String pattern` | Calling this method will add a pattern to the set of `branchNameInSnapshot.includeBranchPatterns`, usage: `nebulaRelease { branchNameInSnapshot { addIncludeBranchPattern(/myregex/)` |
+| branchNameInSnapshot.addExcludeBranchPattern | `String pattern` | Calling this method will add a pattern to the set of `branchNameInSnapshot.excludeBranchPatterns`, usage: `nebulaRelease { branchNameInSnapshot { addExcludeBranchPattern(/myregex/)` |
 
 # Tasks Provided
 

--- a/src/main/groovy/nebula/plugin/release/NetflixOssStrategies.groovy
+++ b/src/main/groovy/nebula/plugin/release/NetflixOssStrategies.groovy
@@ -21,18 +21,57 @@ import org.ajoberstar.gradle.git.release.semver.PartialSemVerStrategy
 import org.ajoberstar.gradle.git.release.semver.SemVerStrategy
 import org.ajoberstar.gradle.git.release.semver.StrategyUtil
 
+import static nebula.plugin.release.NetflixOssStrategies.BuildMetadata.DEVELOPMENT_METADATA_STRATEGY
+import static nebula.plugin.release.NetflixOssStrategies.PreRelease.BRANCH_NAME_STRATEGY
+import static nebula.plugin.release.NetflixOssStrategies.PreRelease.STAGE_APPENDED_STRATEGY
+
 class NetflixOssStrategies {
     private static final scopes = StrategyUtil.one(Strategies.Normal.USE_SCOPE_PROP,
             Strategies.Normal.ENFORCE_GITFLOW_BRANCH_MAJOR_X, Strategies.Normal.ENFORCE_BRANCH_MAJOR_X,
             Strategies.Normal.ENFORCE_GITFLOW_BRANCH_MAJOR_MINOR_X, Strategies.Normal.ENFORCE_BRANCH_MAJOR_MINOR_X,
             Strategies.Normal.USE_NEAREST_ANY, Strategies.Normal.useScope(ChangeScope.MINOR))
 
-    static final SemVerStrategy SNAPSHOT = Strategies.SNAPSHOT.copyWith(normalStrategy: scopes)
+    static final SemVerStrategy SNAPSHOT = Strategies.SNAPSHOT.copyWith(normalStrategy: scopes,
+        preReleaseStrategy: StrategyUtil.all(BRANCH_NAME_STRATEGY, STAGE_APPENDED_STRATEGY))
     static final SemVerStrategy DEVELOPMENT = Strategies.DEVELOPMENT.copyWith(
-            normalStrategy: scopes,
-            buildMetadataStrategy: NetflixOssStrategies.BuildMetadata.DEVELOPMENT_METADATA_STRATEGY)
+            normalStrategy: scopes, buildMetadataStrategy: DEVELOPMENT_METADATA_STRATEGY)
     static final SemVerStrategy PRE_RELEASE = Strategies.PRE_RELEASE.copyWith(normalStrategy: scopes)
     static final SemVerStrategy FINAL = Strategies.FINAL.copyWith(normalStrategy: scopes)
+
+    static final class PreRelease {
+        static ReleaseExtension nebulaReleaseExtension
+
+        /**
+         * Uses the branch name for the pre-release component of the version (if enabled via the extension).
+         */
+        static final PartialSemVerStrategy BRANCH_NAME_STRATEGY = StrategyUtil.closure { state ->
+            boolean needsBranch = false
+            if (nebulaReleaseExtension.branchNameInSnapshot.enabled){
+                nebulaReleaseExtension.branchNameInSnapshot.includeBranchPatterns.each {
+                    if (state.currentBranch.name =~ it) {
+                        needsBranch = true
+                    }
+                }
+                nebulaReleaseExtension.branchNameInSnapshot.excludeBranchPatterns.each {
+                    if (state.currentBranch.name =~ it) {
+                        needsBranch = false
+                    }
+                }
+            }
+
+            def shortenedBranch = (state.currentBranch.name =~ nebulaReleaseExtension.shortenedBranchPattern)[0][1]
+            shortenedBranch = shortenedBranch.replaceAll('_', '.')
+            state.copyWith(inferredPreRelease: needsBranch ? shortenedBranch : state.inferredPreRelease)
+        }
+
+        /**
+         * Like {@link org.ajoberstar.gradle.git.release.opinion.Strategies.PreRelease#STAGE_FIXED} but appends the stage
+         * instead of using a fixed value for the pre-release component of the version.
+         */
+        static final PartialSemVerStrategy STAGE_APPENDED_STRATEGY = StrategyUtil.closure { state ->
+            state.copyWith(inferredPreRelease: state.inferredPreRelease ? "${state.inferredPreRelease}-${state.stageFromProp}" : state.stageFromProp)
+        }
+    }
 
     static final class BuildMetadata {
         static ReleaseExtension nebulaReleaseExtension
@@ -50,4 +89,5 @@ class NetflixOssStrategies {
             state.copyWith(inferredBuildMetadata: metadata)
         }
     }
+
 }

--- a/src/main/groovy/nebula/plugin/release/ReleaseExtension.groovy
+++ b/src/main/groovy/nebula/plugin/release/ReleaseExtension.groovy
@@ -15,9 +15,13 @@
  */
 package nebula.plugin.release
 
+import org.ajoberstar.grgit.util.ConfigureUtil
+
 class ReleaseExtension {
     Set<String> releaseBranchPatterns = [/master/, /HEAD/, /(release(-|\/))?\d+(\.\d+)?\.x/, /v?\d+\.\d+\.\d+/] as Set
     Set<String> excludeBranchPatterns = [] as Set
+
+    BranchNameInSnapshot branchNameInSnapshot = new BranchNameInSnapshot()
 
     /**
      * This should be a regex pattern with one(1) capture group
@@ -30,5 +34,31 @@ class ReleaseExtension {
 
     void addExcludeBranchPattern(String pattern) {
         excludeBranchPatterns.add(pattern)
+    }
+
+    void branchNameInSnapshot(Closure closure){
+        ConfigureUtil.configure(branchNameInSnapshot, closure)
+    }
+
+    /**
+     * Whether to include the branch name in the version for maven style snapshots
+     */
+    class BranchNameInSnapshot {
+        boolean enabled = false
+        Set<String> includeBranchPatterns = [/feature(-|\/).*/] as Set
+        Set<String> excludeBranchPatterns = [] as Set
+
+        void enabled(boolean value){
+            enabled = value
+        }
+
+        void addIncludeBranchPattern(String pattern) {
+            includeBranchPatterns.add(pattern)
+        }
+
+        void addExcludeBranchPattern(String pattern) {
+            excludeBranchPatterns.add(pattern)
+        }
+
     }
 }


### PR DESCRIPTION
This PR adds support for including the branch name in the version for maven-style snapshots (i.e. the `snapshot` task).

This allows concurrent feature branches to be deployed/consumed from Maven independently (otherwise they would all share the same version and madness will ensue!).

It's turned off by default (I wasn't sure if it was too opinionated?), and only applies to feature branches (maybe it's also relevant for `hotfix` if you're using git-flow?).

It's broken a few of the integration tests (I'm not sure why). Any help on fixing them would be appreciated - I'm no gradle plugin expert.

I'm open to any suggestions/improvements :)