### PR TITLE
Updated ReleaseLastTagStrategy to honour a tag strategy set in `release` extension

### DIFF
--- a/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
@@ -411,6 +411,29 @@ class ReleasePluginIntegrationSpec extends GitVersioningIntegrationSpec {
         new File(projectDir, "build/libs/${moduleName}-0.1.0.jar").exists()
     }
 
+    def 'use last tag with custom tag strategy'() {
+        buildFile << '''\
+            release {
+              tagStrategy {
+                toTagString = { vs -> "version${vs}" }
+                parseTag = { tag ->
+                  try { com.github.zafarkhaja.semver.Version.valueOf(tag.name[7..-1]) } catch (Exception e) { null }
+                }
+              }
+            }
+        '''.stripIndent()
+        git.add(patterns: ['build.gradle'] as Set)
+        git.commit(message: 'setting tag strategy')
+
+        git.tag.add(name: 'version19.71.1')
+
+        when:
+        runTasksSuccessfully('final', '-Prelease.useLastTag=true')
+
+        then:
+        new File(projectDir, "build/libs/${moduleName}-19.71.1.jar").exists()
+    }
+
     def 'able to release with the override of version calculation'() {
         when:
         runTasksSuccessfully('final', '-Prelease.version=42.5.0')

--- a/src/main/groovy/nebula/plugin/release/OverrideStrategies.groovy
+++ b/src/main/groovy/nebula/plugin/release/OverrideStrategies.groovy
@@ -15,6 +15,7 @@
  */
 package nebula.plugin.release
 
+import org.ajoberstar.gradle.git.release.base.ReleasePluginExtension
 import org.ajoberstar.gradle.git.release.base.ReleaseVersion
 import org.ajoberstar.gradle.git.release.base.TagStrategy
 import org.ajoberstar.gradle.git.release.base.VersionStrategy
@@ -57,7 +58,8 @@ class OverrideStrategies {
 
         @Override
         ReleaseVersion infer(Project project, Grgit grgit) {
-            def locate = new NearestVersionLocator(new TagStrategy()).locate(grgit)
+            def tagStrategy = project.extensions.getByType(ReleasePluginExtension).tagStrategy
+            def locate = new NearestVersionLocator(tagStrategy).locate(grgit)
             return new ReleaseVersion(locate.any.toString(), null, false)
         }
     }


### PR DESCRIPTION
The  implementation of ReleaseLastTagStrategy created a new TagStrategy object instead of using the one defined in `release` extension. Which in a case of custom logic of parsing and producing version tags  could cause  `-Prelease.useLastTag=true` option not to work properly.
