### PR TITLE
Allow plugin to work with no git repo or one with no commits. Fixes #59.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+4.2.0 / 2017-03-29
+==================
+
+* Calculate version in repository with no commits
+
 4.0.1 / 2016-02-05
 ==================
 

--- a/src/integTest/groovy/nebula/plugin/release/ReleasePluginNoCommitIntegrationSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/release/ReleasePluginNoCommitIntegrationSpec.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nebula.plugin.release
+
+import nebula.test.IntegrationSpec
+import org.ajoberstar.grgit.Grgit
+import org.gradle.api.plugins.JavaPlugin
+
+class ReleasePluginNoCommitIntegrationSpec extends IntegrationSpec {
+    Grgit repo
+
+    def 'repo with no commits does not throw errors'() {
+        given:
+        repo = Grgit.init(dir: projectDir)
+        buildFile << """\
+            ext.dryRun = true
+            group = 'test'
+            ${applyPlugin(ReleasePlugin)}
+            ${applyPlugin(JavaPlugin)}
+
+            task showVersion {
+                doLast {
+                    logger.lifecycle "Version in task: \${version.toString()}"
+                }
+            }
+            """.stripIndent()
+
+        when:
+        def results = runTasks('showVersion')
+
+        then:
+        results.standardOutput.contains 'Version in task: 0.1.0-dev.0.uncommitted'
+    }
+}

--- a/src/integTest/groovy/nebula/plugin/release/ReleasePluginNoRepoIntegrationSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/release/ReleasePluginNoRepoIntegrationSpec.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nebula.plugin.release
+
+import nebula.test.IntegrationSpec
+import org.gradle.api.plugins.JavaPlugin
+
+class ReleasePluginNoRepoIntegrationSpec extends IntegrationSpec {
+    def 'calculate version with no commits'() {
+        given:
+        buildFile << """\
+            ext.dryRun = true
+            group = 'test'
+            ${applyPlugin(ReleasePlugin)}
+            ${applyPlugin(JavaPlugin)}
+
+            task showVersion {
+                doLast {
+                    logger.lifecycle "Version in task: \${version.toString()}"
+                }
+            }
+            """.stripIndent()
+
+        when:
+        def results = runTasksSuccessfully('showVersion')
+
+        then:
+        results.standardOutput.contains 'Version in task: 0.1.0-dev.0.uncommitted'
+    }
+}

--- a/src/main/groovy/nebula/plugin/release/OverrideStrategies.groovy
+++ b/src/main/groovy/nebula/plugin/release/OverrideStrategies.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Netflix, Inc.
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@ package nebula.plugin.release
 
 import org.ajoberstar.gradle.git.release.base.ReleasePluginExtension
 import org.ajoberstar.gradle.git.release.base.ReleaseVersion
-import org.ajoberstar.gradle.git.release.base.TagStrategy
 import org.ajoberstar.gradle.git.release.base.VersionStrategy
 import org.ajoberstar.gradle.git.release.semver.NearestVersionLocator
 import org.ajoberstar.grgit.Grgit
+import org.ajoberstar.grgit.exception.GrgitException
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 
@@ -91,6 +91,29 @@ class OverrideStrategies {
                 throw new GradleException('Supplied release.version is empty')
             }
             new ReleaseVersion(requestedVersion, null, true)
+        }
+    }
+
+    static class NoCommitStrategy implements VersionStrategy {
+        @Override
+        String getName() {
+            'no-commit'
+        }
+
+        @Override
+        boolean selector(Project project, Grgit grgit) {
+            try {
+                grgit.head()
+            } catch (GrgitException ex) {
+                return true
+            }
+
+            return false
+        }
+
+        @Override
+        ReleaseVersion infer(Project project, Grgit grgit) {
+            new ReleaseVersion('0.1.0-dev.0.uncommitted', null, false)
         }
     }
 }

--- a/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 Netflix, Inc.
+ * Copyright 2014-2017 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package nebula.plugin.release
+
 import com.jfrog.bintray.gradle.BintrayUploadTask
 import nebula.core.ProjectType
 import org.ajoberstar.gradle.git.release.base.BaseReleasePlugin
@@ -24,7 +25,6 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.execution.TaskExecutionGraph
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.plugins.JavaPlugin
@@ -59,6 +59,7 @@ class ReleasePlugin implements Plugin<Project> {
             git = Grgit.open(dir: gitRoot)
         }
         catch(RepositoryNotFoundException e) {
+            this.project.version = '0.1.0-dev.0.uncommitted'
             logger.warn("Git repository not found at $gitRoot -- nebula-release tasks will not be available. Use the git.root Gradle property to specify a different directory.")
             return
         }
@@ -69,6 +70,7 @@ class ReleasePlugin implements Plugin<Project> {
             project.plugins.apply(BaseReleasePlugin)
             ReleasePluginExtension releaseExtension = project.extensions.findByType(ReleasePluginExtension)
             releaseExtension.with {
+                versionStrategy new OverrideStrategies.NoCommitStrategy()
                 versionStrategy new OverrideStrategies.ReleaseLastTagStrategy(project)
                 versionStrategy new OverrideStrategies.GradlePropertyStrategy(project)
                 versionStrategy NetflixOssStrategies.SNAPSHOT


### PR DESCRIPTION
The try catch seems a little dirty but probably the easiest way to determine if its an empty repo that I can see. If you guys have a better idea from grgit or jgit will swap.