### PR TITLE
List Files Considered Changed When !isClean()

### DIFF
--- a/src/main/groovy/nebula/plugin/release/ErrorMessageFormatter.groovy
+++ b/src/main/groovy/nebula/plugin/release/ErrorMessageFormatter.groovy
@@ -1,0 +1,43 @@
+package nebula.plugin.release
+
+import groovy.transform.CompileStatic
+import org.ajoberstar.grgit.Status
+
+@CompileStatic
+class ErrorMessageFormatter {
+    static final String ROOT_CAUSE = 'Final and candidate builds require all changes to be committed into Git.'
+    static final String NEW_LINE = sprintf("%n")
+
+    String format(Status status) {
+        if (status.isClean()) {
+            return ""
+        }
+        StringBuilder sb = new StringBuilder(ROOT_CAUSE)
+        if (status.staged.allChanges) {
+            sb.append(header('staged changes'))
+            sb.append(annotate(status.staged))
+        }
+        if (status.unstaged.allChanges) {
+            sb.append(header('unstaged changes'))
+            sb.append(annotate(status.unstaged))
+        }
+        if(status.conflicts) {
+            sb.append(header('conflicts'))
+            def conflicts = status.conflicts.collect { "  $it" }
+            sb.append(conflicts.join(NEW_LINE))
+        }
+        return sb.toString()
+    }
+
+    private static String header(String name) {
+        [NEW_LINE, "Found $name:", NEW_LINE].join('')
+    }
+
+    private static String annotate(Status.Changes changes) {
+        def added = changes.added.collect { "  [+] $it" }
+        def modified = changes.modified.collect { "  [M] $it"}
+        def removed = changes.removed.collect { "  [-] $it"}
+        return [added, modified, removed].flatten().join(NEW_LINE)
+    }
+
+}

--- a/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
@@ -20,6 +20,7 @@ import nebula.core.ProjectType
 import org.ajoberstar.gradle.git.release.base.BaseReleasePlugin
 import org.ajoberstar.gradle.git.release.base.ReleasePluginExtension
 import org.ajoberstar.grgit.Grgit
+import org.ajoberstar.grgit.Status
 import org.eclipse.jgit.errors.RepositoryNotFoundException
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
@@ -200,10 +201,10 @@ class ReleasePlugin implements Plugin<Project> {
 
     private void checkStateForStage() {
         if (!project.tasks.releaseCheck.isSnapshotRelease) {
-            def status = git.status()
-            def uncommittedChangesFound = [status.staged, status.unstaged].any { it.getAllChanges().size() > 0 }
-            if (uncommittedChangesFound) {
-                throw new GradleException('Final and candidate builds require all changes to be committed into Git.')
+            Status status = git.status()
+            if (!status.isClean()) {
+                String message = new ErrorMessageFormatter().format(status)
+                throw new GradleException(message)
             }
         }
     }

--- a/src/test/groovy/nebula/plugin/release/ErrorMessageFormatterSpec.groovy
+++ b/src/test/groovy/nebula/plugin/release/ErrorMessageFormatterSpec.groovy
@@ -1,0 +1,75 @@
+package nebula.plugin.release
+
+import org.ajoberstar.grgit.Status
+import spock.lang.Specification
+
+class ErrorMessageFormatterSpec extends Specification {
+    ErrorMessageFormatter formatter = new ErrorMessageFormatter()
+
+    def 'should not have a message for clean status'() {
+        given:
+        def status = new Status()
+
+        expect:
+        status.isClean()
+        formatter.format(status) == ""
+    }
+
+    def 'should list staged files'() {
+        given:
+        def status = new Status(['staged':['added': ['add.txt'], 'modified': ['path/to/mod.txt', 'mod.b.txt'], 'removed': ['folder/rm.txt']]])
+        String expected = [
+                ErrorMessageFormatter.ROOT_CAUSE,
+                "Found staged changes:",
+                "  [+] add.txt",
+                "  [M] path/to/mod.txt",
+                "  [M] mod.b.txt",
+                "  [-] folder/rm.txt",
+        ].join(sprintf(ErrorMessageFormatter.NEW_LINE))
+
+        when:
+        String message = formatter.format(status)
+
+        then:
+        !status.isClean()
+        message == expected
+    }
+
+    def 'should list unstaged files'() {
+        given:
+        def status = new Status(['unstaged':['added': ['z.txt'], 'modified': ['a/b/c.txt'], 'removed': ['sub/folder/file.txt', 'version.txt']]])
+        String expected = [
+                ErrorMessageFormatter.ROOT_CAUSE,
+                "Found unstaged changes:",
+                "  [+] z.txt",
+                "  [M] a/b/c.txt",
+                "  [-] sub/folder/file.txt",
+                "  [-] version.txt",
+        ].join(sprintf(ErrorMessageFormatter.NEW_LINE))
+
+        when:
+        String message = formatter.format(status)
+
+        then:
+        !status.isClean()
+        message == expected
+    }
+
+    def 'should list conflict files'() {
+        given:
+        def status = new Status(['conflicts':['a.txt', 'b.java']])
+        String expected = [
+                ErrorMessageFormatter.ROOT_CAUSE,
+                "Found conflicts:",
+                "  a.txt",
+                "  b.java",
+        ].join(sprintf(ErrorMessageFormatter.NEW_LINE))
+
+        when:
+        String message = formatter.format(status)
+
+        then:
+        !status.isClean()
+        message == expected
+    }
+}


### PR DESCRIPTION
Produces a list of files that are added, modified, or removed (staged or unstaged) or newly in conflict. The plugin now also uses GrGit's `isClean` logic, which considers staged, unstaged, and conflicts.

This should help troubleshoot in situations where JGit and git differ in their opinion of whether or not the workspace is clean.