### PR TITLE
BaseReleasePluginSpec refactor

### DIFF
--- a/src/main/groovy/nebula/plugin/release/git/base/BaseReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/base/BaseReleasePlugin.groovy
@@ -76,7 +76,7 @@ class BaseReleasePlugin implements Plugin<Project> {
         }
     }
 
-    protected void prepare(ReleasePluginExtension extension) {
+    protected static void prepare(ReleasePluginExtension extension) {
         logger.info('Fetching changes from remote: {}', extension.remote)
         Grgit grgit = extension.grgit
         grgit.fetch(remote: extension.remote)
@@ -88,7 +88,7 @@ class BaseReleasePlugin implements Plugin<Project> {
         }
     }
 
-    protected void release(Project project, ext, ReleasePluginExtension extension) {
+    protected static void release(Project project, ext, ReleasePluginExtension extension) {
         // force version inference if it hasn't happened already
         project.version.toString()
 

--- a/src/test/groovy/nebula/plugin/release/git/base/BaseReleasePluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/release/git/base/BaseReleasePluginSpec.groovy
@@ -15,6 +15,9 @@
  */
 package nebula.plugin.release.git.base
 
+import nebula.plugin.release.ReleasePlugin
+import nebula.test.IntegrationSpec
+import nebula.test.ProjectSpec
 import org.ajoberstar.grgit.Branch
 import org.ajoberstar.grgit.BranchStatus
 import org.ajoberstar.grgit.Grgit
@@ -23,12 +26,16 @@ import org.ajoberstar.grgit.service.TagService
 
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.internal.tasks.TaskExecuter
+import org.gradle.api.internal.tasks.execution.DefaultTaskExecutionContext
+import org.gradle.api.plugins.JavaPlugin
 import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.util.DeprecationLogger
 import spock.lang.Ignore
 import spock.lang.Specification
 
-@Ignore("Task.execute() is not present anymore and this code should be refactored")
-class BaseReleasePluginSpec extends Specification {
+//@Ignore("Task.execute() is not present anymore and this code should be refactored")
+class BaseReleasePluginSpec extends IntegrationSpec {
     Project project = ProjectBuilder.builder().build()
 
     def setup() {

--- a/src/test/groovy/nebula/plugin/release/git/base/BaseReleasePluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/release/git/base/BaseReleasePluginSpec.groovy
@@ -15,27 +15,17 @@
  */
 package nebula.plugin.release.git.base
 
-import nebula.plugin.release.ReleasePlugin
-import nebula.test.IntegrationSpec
-import nebula.test.ProjectSpec
 import org.ajoberstar.grgit.Branch
 import org.ajoberstar.grgit.BranchStatus
 import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.service.BranchService
 import org.ajoberstar.grgit.service.TagService
-
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.internal.tasks.TaskExecuter
-import org.gradle.api.internal.tasks.execution.DefaultTaskExecutionContext
-import org.gradle.api.plugins.JavaPlugin
 import org.gradle.testfixtures.ProjectBuilder
-import org.gradle.util.DeprecationLogger
-import spock.lang.Ignore
 import spock.lang.Specification
 
-//@Ignore("Task.execute() is not present anymore and this code should be refactored")
-class BaseReleasePluginSpec extends IntegrationSpec {
+class BaseReleasePluginSpec extends Specification {
     Project project = ProjectBuilder.builder().build()
 
     def setup() {
@@ -46,98 +36,111 @@ class BaseReleasePluginSpec extends IntegrationSpec {
         given:
         Grgit repo = GroovyMock()
         BranchService branch = GroovyMock()
-        repo.branch >> branch
         branch.current() >> new Branch(fullName: 'refs/heads/master')
         branch.status([branch: 'refs/heads/master']) >> new BranchStatus(behindCount: 0)
+        ReleasePluginExtension releaseExtension = new ReleasePluginExtension(project)
+        releaseExtension.grgit = repo
 
-        project.release {
-            grgit = repo
-        }
         when:
-        project.tasks.prepare.execute()
+        BaseReleasePlugin.prepare(releaseExtension)
+
         then:
         notThrown(GradleException)
+        1 * repo.branch >> branch
         1 * repo.fetch([remote: 'origin'])
+
     }
 
     def 'prepare task fails if branch is behind'() {
         given:
         Grgit repo = GroovyMock()
         BranchService branch = GroovyMock()
-        repo.branch >> branch
-        branch.current >> new Branch(fullName: 'refs/heads/master', trackingBranch: new Branch(fullName: 'refs/remotes/origin/master'))
-        branch.status([branch: 'refs/heads/master']) >> new BranchStatus(behindCount: 2)
+        ReleasePluginExtension releaseExtension = new ReleasePluginExtension(project)
+        releaseExtension.grgit = repo
 
-        project.release {
-            grgit = repo
-        }
         when:
-        project.tasks.prepare.execute()
+        BaseReleasePlugin.prepare(releaseExtension)
+
         then:
         thrown(GradleException)
         1 * repo.fetch([remote: 'origin'])
+        _ * repo.branch >> branch
+        1 * branch.status([name: 'refs/heads/master']) >> new BranchStatus(behindCount: 2)
+        1 * branch.current() >> new Branch(fullName: 'refs/heads/master', trackingBranch: new Branch(fullName: 'refs/remotes/origin/master'))
+
     }
 
     def 'release task pushes branch and tag if created'() {
         given:
+        VersionStrategy strategy = [
+                getName: { 'a' },
+                selector: {proj, repo2 -> true },
+                infer: {proj, repo2 -> new ReleaseVersion('1.2.3', null, true)}] as VersionStrategy
         Grgit repo = GroovyMock()
         BranchService branch = GroovyMock()
         repo.branch >> branch
         TagService tag = GroovyMock()
-        repo.tag >> tag
-        branch.current >> new Branch(fullName: 'refs/heads/master', trackingBranch: new Branch(fullName: 'refs/remotes/origin/master'))
-        project.release {
-            versionStrategy([
-                getName: { 'a' },
-                selector: {proj, repo2 -> true },
-                infer: {proj, repo2 -> new ReleaseVersion('1.2.3', null, true)}] as VersionStrategy)
-            grgit = repo
-        }
+
+        ReleasePluginExtension releaseExtension = new ReleasePluginExtension(project)
+        releaseExtension.grgit = repo
+        releaseExtension.versionStrategy(strategy)
+
         when:
-        project.tasks.release.execute()
+        BaseReleasePlugin.release(project, project.ext, releaseExtension)
+
         then:
         1 * repo.push([remote: 'origin', refsOrSpecs: ['refs/heads/master', 'v1.2.3']])
+        _ * repo.branch >> branch
+        _ * branch.current >> new Branch(fullName: 'refs/heads/master', trackingBranch: new Branch(fullName: 'refs/remotes/origin/master'))
+        1 * repo.tag >> tag
     }
 
     def 'release task pushes branch but not tag if it was not created'() {
         given:
-        Grgit repo = GroovyMock()
-        BranchService branch = GroovyMock()
-        repo.branch >> branch
-        TagService tag = GroovyMock()
-        repo.tag >> tag
-        branch.current >> new Branch(fullName: 'refs/heads/master', trackingBranch: new Branch(fullName: 'refs/remotes/origin/master'))
-        project.release {
-            versionStrategy([
+        VersionStrategy strategy = [
                 getName: { 'a' },
                 selector: {proj, repo2 -> true },
-                infer: {proj, repo2 -> new ReleaseVersion('1.2.3', null, false)}] as VersionStrategy)
-            grgit = repo
-        }
+                infer: {proj, repo2 -> new ReleaseVersion('1.2.3', null, false)}] as VersionStrategy
+        Grgit repo = GroovyMock()
+        BranchService branch = GroovyMock()
+
+        ReleasePluginExtension releaseExtension = new ReleasePluginExtension(project)
+        releaseExtension.grgit = repo
+        releaseExtension.versionStrategy(strategy)
+
         when:
-        project.tasks.release.execute()
+        BaseReleasePlugin.release(project, project.ext, releaseExtension)
+
         then:
         1 * repo.push([remote: 'origin', refsOrSpecs: ['refs/heads/master']])
+        _ * repo.branch >> branch
+        _ * branch.current >> new Branch(fullName: 'refs/heads/master', trackingBranch: new Branch(fullName: 'refs/remotes/origin/master'))
+        0 * repo.tag
+
     }
 
     def 'release task skips push if on detached head'() {
         given:
+        VersionStrategy strategy = [
+                getName: { 'a' },
+                selector: {proj, repo2 -> true },
+                infer: {proj, repo2 -> new ReleaseVersion('1.2.3', null, false)}] as VersionStrategy
         Grgit repo = GroovyMock()
         BranchService branch = GroovyMock()
         repo.branch >> branch
-        TagService tag = GroovyMock()
-        repo.tag >> tag
-        branch.current >> new Branch(fullName: 'HEAD')
-        project.release {
-            versionStrategy([
-                getName: { 'a' },
-                selector: {proj, repo2 -> true },
-                infer: {proj, repo2 -> new ReleaseVersion('1.2.3', null, false)}] as VersionStrategy)
-            grgit = repo
-        }
+
+
+        ReleasePluginExtension releaseExtension = new ReleasePluginExtension(project)
+        releaseExtension.grgit = repo
+        releaseExtension.versionStrategy(strategy)
+
         when:
-        project.tasks.release.execute()
+        BaseReleasePlugin.release(project, project.ext, releaseExtension)
+
         then:
+        1 * branch.current >> new Branch(fullName: 'HEAD')
         0 * repo.push(_)
+        0 * repo.tag
+
     }
 }


### PR DESCRIPTION
`nebula-release` plugin was modified to include code from `gradle-git`.

During the migration of this code, the tests were moved as of that day and now that we are moving to gradle 5, tests in `BaseReleasePluginSpec` won't execute because `TaskInternal.execute()` was removed in https://github.com/gradle/gradle/commit/6521f6cde0de047822d590a164fa933a0530ff1f#diff-5a073fcafa933576d519372602f7d109

Doing the following is not a good pattern `project.tasks.prepare.execute()`

 

