### PR TITLE
Include dependency constraint on jgit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,11 @@ contacts {
 }
 
 dependencies {
+    constraints {
+        compile('org.eclipse.jgit:org.eclipse.jgit:5.1.1.201809181055-r') {
+            because "Release plugin's call to `git.branch.current` throws MissingMethodException with transitive of grgit-core"
+        }
+    }
     compile ('org.ajoberstar.grgit:grgit-core:3.0.0-beta.1') {
         exclude group: 'org.codehaus.groovy', module: 'groovy'
     }


### PR DESCRIPTION
jgit is currently throwing a 
```No signature of method: org.eclipse.jgit.internal.storage.file.FileRepository.getRef()``` in some scenarios, but upgrading to the latest fixes this problem

cc @tgianos