### PR TITLE
Refactor netflixossstrategies

### DIFF
--- a/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
@@ -545,7 +545,7 @@ class ReleasePluginIntegrationSpec extends GitVersioningIntegrationSpec {
     def 'devSnapshot works if default is changed'() {
         buildFile << '''\
             release {
-                defaultVersionStrategy = nebula.plugin.release.NetflixOssStrategies.SNAPSHOT
+                defaultVersionStrategy = nebula.plugin.release.NetflixOssStrategies.SNAPSHOT(project)
             }
         '''.stripIndent()
         git.add(patterns: ['build.gradle'] as Set)

--- a/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
@@ -57,7 +57,6 @@ class ReleasePlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         this.project = project
-        NetflixOssStrategies netflixOssStrategies = new NetflixOssStrategies(project)
 
         def gitRoot = project.hasProperty('git.root') ? project.property('git.root') : project.rootProject.projectDir
 
@@ -77,11 +76,11 @@ class ReleasePlugin implements Plugin<Project> {
                 versionStrategy new OverrideStrategies.NoCommitStrategy()
                 versionStrategy new OverrideStrategies.ReleaseLastTagStrategy(project)
                 versionStrategy new OverrideStrategies.GradlePropertyStrategy(project)
-                versionStrategy netflixOssStrategies.snapshot
-                versionStrategy netflixOssStrategies.development
-                versionStrategy netflixOssStrategies.preRelease
-                versionStrategy netflixOssStrategies.final
-                defaultVersionStrategy = netflixOssStrategies.development
+                versionStrategy NetflixOssStrategies.SNAPSHOT(project)
+                versionStrategy NetflixOssStrategies.DEVELOPMENT(project)
+                versionStrategy NetflixOssStrategies.PRE_RELEASE(project)
+                versionStrategy NetflixOssStrategies.FINAL(project)
+                defaultVersionStrategy = NetflixOssStrategies.DEVELOPMENT(project)
             }
 
             releaseExtension.with {

--- a/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
@@ -57,7 +57,7 @@ class ReleasePlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         this.project = project
-        NetflixOssStrategies.project = project
+        NetflixOssStrategies netflixOssStrategies = new NetflixOssStrategies(project)
 
         def gitRoot = project.hasProperty('git.root') ? project.property('git.root') : project.rootProject.projectDir
 
@@ -77,11 +77,11 @@ class ReleasePlugin implements Plugin<Project> {
                 versionStrategy new OverrideStrategies.NoCommitStrategy()
                 versionStrategy new OverrideStrategies.ReleaseLastTagStrategy(project)
                 versionStrategy new OverrideStrategies.GradlePropertyStrategy(project)
-                versionStrategy NetflixOssStrategies.SNAPSHOT
-                versionStrategy NetflixOssStrategies.DEVELOPMENT
-                versionStrategy NetflixOssStrategies.PRE_RELEASE
-                versionStrategy NetflixOssStrategies.FINAL
-                defaultVersionStrategy = NetflixOssStrategies.DEVELOPMENT
+                versionStrategy netflixOssStrategies.snapshot
+                versionStrategy netflixOssStrategies.development
+                versionStrategy netflixOssStrategies.preRelease
+                versionStrategy netflixOssStrategies.final
+                defaultVersionStrategy = netflixOssStrategies.development
             }
 
             releaseExtension.with {


### PR DESCRIPTION
`NetflixOssStrategies.project = project` was detected as a potential memory leak.

This quick refactor is just to stop doing this and instead pass the project as an argument and use it to determine the `release.travisBranch` property.

While this introduces a breaking change such as 

`defaultVersionStrategy = nebula.plugin.release.NetflixOssStrategies.SNAPSHOT(project)` in favor of `nebula.plugin.release.NetflixOssStrategies.SNAPSHOT`, I believe it would be ok for now since we are the only consumers of this strategy and we don't use it heavily.

Unfortunately, other strategies do not depend on project properties so it makes easier to do everything in a static context -> https://github.com/nebula-plugins/nebula-release-plugin/blob/master/src/main/groovy/nebula/plugin/release/git/opinion/Strategies.groovy

While this is not the cleanest approach for this, I think we really want to potentially move away from how we do release plugin and re implement these portions but that's a major effort.

Also, this memory leak happens regardless if you use the strategies or not.