### PR TITLE
useLastTag should be used with a release strategy…

### DIFF
--- a/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
@@ -560,7 +560,7 @@ class ReleasePluginIntegrationSpec extends GitVersioningIntegrationSpec {
         def result = runTasksWithFailure('assemble', '-Prelease.useLastTag=true')
 
         then:
-        result.standardError.contains "Current commit has a snapshot or devSnapshot tag. 'useLastTag' requires a prerelease or release tag."
+        result.standardError.contains "Current commit has a snapshot or devSnapshot tag. 'useLastTag' requires a prerelease or final tag."
         !new File(projectDir, "build/libs/${moduleName}-${dev('0.1.0-dev.3+').toString()}.jar").exists()
     }
 
@@ -571,7 +571,7 @@ class ReleasePluginIntegrationSpec extends GitVersioningIntegrationSpec {
         def result = runTasksWithFailure('assemble', '-Prelease.useLastTag=true')
 
         then:
-        result.standardError.contains "Current commit has a snapshot or devSnapshot tag. 'useLastTag' requires a prerelease or release tag."
+        result.standardError.contains "Current commit has a snapshot or devSnapshot tag. 'useLastTag' requires a prerelease or final tag."
         !new File(projectDir, "build/libs/${moduleName}-1.2.3-SNAPSHOT.jar").exists()
     }
 


### PR DESCRIPTION
but does not require it

Plugin will use semantically highest version on the commit when release strategy is not passed in