### PR TITLE
Better error when last tag is not a valid version. The hope is to provide more context when someone intent to release final or candidate but have a typo in a tag.

### DIFF
--- a/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
@@ -462,6 +462,20 @@ class ReleasePluginIntegrationSpec extends GitVersioningIntegrationSpec {
         !new File(projectDir, "build/libs/${moduleName}-42.5.3.jar").exists()
     }
 
+    def 'useLastTag errors out if there is a tag in incorrect format'() {
+        git.tag.add(name: 'v42.5.3')
+        new File(projectDir, "foo").text = "Hi"
+        git.add(patterns: ['foo'] as Set)
+        git.commit(message: 'Something got committed')
+        git.tag.add(name: 'v42.5.4-rc.01')
+
+        when:
+        def result = runTasksWithFailure('candidate', '-Prelease.useLastTag=true')
+
+        then:
+        result.standardError.contains 'Current commit has following tags: [v42.5.4-rc.01] but they were not recognized as valid versions'
+    }
+
     def 'use last tag for rc'() {
         git.tag.add(name: 'v3.1.2-rc.1')
 

--- a/src/main/groovy/nebula/plugin/release/OverrideStrategies.groovy
+++ b/src/main/groovy/nebula/plugin/release/OverrideStrategies.groovy
@@ -20,6 +20,7 @@ import nebula.plugin.release.git.base.ReleaseVersion
 import nebula.plugin.release.git.base.VersionStrategy
 import nebula.plugin.release.git.semver.NearestVersionLocator
 import org.ajoberstar.grgit.Grgit
+import org.ajoberstar.grgit.Tag
 import org.eclipse.jgit.api.errors.RefNotFoundException
 import org.gradle.api.GradleException
 import org.gradle.api.Project
@@ -97,7 +98,12 @@ class OverrideStrategies {
                 logger.debug("Using version ${locate.any.toString()} with ${releaseStage == NOT_SUPPLIED ? "a non-supplied release strategy" : "${releaseStage} release strategy"}")
                 return new ReleaseVersion(locate.any.toString(), null, false)
             } else {
-                throw new GradleException("Current commit does not have a tag")
+                List<Tag> headTags = grgit.tag.list().findAll { it.commit == grgit.head()}
+                if (headTags.isEmpty()) {
+                    throw new GradleException("Current commit does not have a tag")
+                } else {
+                    throw new GradleException("Current commit has following tags: ${headTags.collect{it.name}} but they were not recognized as valid versions" )
+                }
             }
         }
     }


### PR DESCRIPTION
Plugin will find latest succesful release tag but because it won't be on current commit it will fail with a message listing actually present on the current commit.

Example: Tags like v1.0.0-rc.01 are not valid because leading zeros in rc count.