### PR TITLE
Introduce ImmutableSnapshot strategy to create snapshots using timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ All tasks will trigger gradle-git's release task which is configured to depend o
 * immutableSnapshot - Sets the version to the appropriate `<major>.<minor>.<patch>-snapshot.<timestamp>+<hash>`, does not create a tag. Where `timestamp` is UTC time in `YYYYMMddHHmmssSSS` format, ex. `20190705210556893`  and `hash` is the git hash of the current commit.  If releasing a immutableSnapshot from a branch not listed in the `releaseBranchPatterns` and not excluded by `excludeBranchPatterns` the version will be `<major>.<minor>.<patch>-snapshot.<timestamp>+<branchname>.<hash>`
 * snapshot - Sets the version to the appropriate `<major>.<minor>.<patch>-SNAPSHOT`, does not create a tag.
 
-Use of immutableSnapshot vs devSnapshot vs snapshot is a project by project choice of whether you want maven style versioning (snapshot) or unique semantic versioned snapshots (devSnapshot) or unique semantic versioned snapshots that guaranteed uniqueness (immutableSnapshot).
+Use of immutableSnapshot vs devSnapshot vs snapshot is a project by project choice of whether you want maven style versioning (snapshot) or semantic versioned snapshots (devSnapshot) or unique semantic versioned snapshots that guaranteed uniqueness (immutableSnapshot).
 
 # Versioning Notes
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This plugin provides opinions and tasks for the release process provided by [gra
 # Applying the plugin
 
     plugins {
-        id 'nebula.release' version '6.3.5'
+        id 'nebula.release' version '10.1.2'
     }
 
 -or-
@@ -20,7 +20,7 @@ This plugin provides opinions and tasks for the release process provided by [gra
     buildscript {
         repositories { jcenter() }
         dependencies {
-            classpath 'com.netflix.nebula:nebula-release-plugin:6.3.5'
+            classpath 'com.netflix.nebula:nebula-release-plugin:10.1.2'
         }
     }
     apply plugin: 'nebula.release'
@@ -73,9 +73,10 @@ All tasks will trigger gradle-git's release task which is configured to depend o
 * final - Sets the version to the appropriate `<major>.<minor>.<patch>`, creates tag `v<major>.<minor>.<patch>`
 * candidate - Sets the version to the appropriate `<major>.<minor>.<patch>-rc.#`, creates tag `v<major>.<minor>.<patch>-rc.#` where `#` is the number of release candidates for this version produced so far. 1st 1.0.0 will be 1.0.0-rc.1, 2nd 1.0.0-rc.2 and so on.
 * devSnapshot - Sets the version to the appropriate `<major>.<minor>.<patch>-dev.#+<hash>`, does not create a tag. Where `#` is the number of commits since the last release and `hash` is the git hash of the current commit.  If releasing a devSnapshot from a branch not listed in the `releaseBranchPatterns` and not excluded by `excludeBranchPatterns` the version will be `<major>.<minor>.<patch>-dev.#+<branchname>.<hash>`
+* immutableSnapshot - Sets the version to the appropriate `<major>.<minor>.<patch>-snapshot.<timestamp>+<hash>`, does not create a tag. Where `timestamp` is UTC time in `YYYYMMddHHmmssSSS` format, ex. `20190705210556893`  and `hash` is the git hash of the current commit.  If releasing a immutableSnapshot from a branch not listed in the `releaseBranchPatterns` and not excluded by `excludeBranchPatterns` the version will be `<major>.<minor>.<patch>-snapshot.<timestamp>+<branchname>.<hash>`
 * snapshot - Sets the version to the appropriate `<major>.<minor>.<patch>-SNAPSHOT`, does not create a tag.
 
-Use of devSnapshot vs snapshot is a project by project choice of whether you want maven style versioning (snapshot) or unique semantic versioned snapshots (devSnapshot).
+Use of immutableSnapshot vs devSnapshot vs snapshot is a project by project choice of whether you want maven style versioning (snapshot) or unique semantic versioned snapshots (devSnapshot) or unique semantic versioned snapshots that guaranteed uniqueness (immutableSnapshot).
 
 # Versioning Notes
 
@@ -141,6 +142,13 @@ The plugin assumes Git root is in the same location as Gradle root. If this isn'
 * `postRelease` - any steps you want to happen after the repo tag, in our case this is where publishing happens since if the publish partially fails we don't want to fix the tags, dependsOn `release`
 * `devSnapshot` - command line task to kick off devSnapshot workflow, dependsOn `postRelease`
 
+### For `immutableSnapshot`
+
+* `immutableSnapshotSetup` - any kind of setup is good to live around here, e.g. setting status, various checks
+* `release` - probably have `release` dependOn any `assemble` and `check` tasks, dependsOn `immutableSnapshotSetup`
+* `postRelease` - any steps you want to happen after the repo tag, in our case this is where publishing happens since if the publish partially fails we don't want to fix the tags, dependsOn `release`
+* `immutableSnapshot` - command line task to kick off immutableSnapshot workflow, dependsOn `postRelease`
+
 ### For `snapshot`
 
 * `snapshotSetup` - any kind of setup is good to live around here, e.g. setting status, various checks
@@ -165,20 +173,22 @@ The plugin assumes Git root is in the same location as Gradle root. If this isn'
 Gradle and Java Compatibility
 =============================
 
-Built with Oracle JDK7
-Tested with Oracle JDK8
+Built with OpenJDK8
+Tested with OpenJDK8
 
 | Gradle Version | Works |
 | :------------: | :---: |
-| 2.13           | yes   |
-| 3.3            | yes   |
-| 3.4.1          | yes   |
-| 3.5            | yes   |
+| 5.0            | yes   |
+| 5.1            | yes   |
+| 5.2            | yes   |
+| 5.3            | yes   |
+| 5.4            | yes   |
+| 5.5            | yes   |
 
 LICENSE
 =======
 
-Copyright 2014-2017 Netflix, Inc.
+Copyright 2014-2019 Netflix, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
@@ -497,6 +497,7 @@ class ReleasePluginIntegrationSpec extends GitVersioningIntegrationSpec {
         then:
         version.toString().startsWith("0.1.0-snapshot." + getUtcDateForComparison())
         version.toString().contains('+testexample.')
+        !version.toString().contains('+feature/testexample.')
     }
 
     def 'version includes branch name with underscores on devSnapshot of non release branch'() {

--- a/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
@@ -918,7 +918,7 @@ class ReleasePluginIntegrationSpec extends GitVersioningIntegrationSpec {
 
         then:
         version.toString().startsWith('0.1.0-snapshot.' + getUtcDateForComparison())
-        version.toString().contains('.robtest.')
+        version.toString().contains('+dev.robtest.')
     }
 
     def 'Can release final version with + not considered as pre-release'() {

--- a/src/integTest/groovy/nebula/plugin/release/ReleasePluginIvyStatusIntegrationSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/release/ReleasePluginIvyStatusIntegrationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Netflix, Inc.
+ * Copyright 2015-2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,6 +90,15 @@ class ReleasePluginIvyStatusIntegrationSpec extends GitVersioningIntegrationSpec
     def 'devSnapshot leaves integration status'() {
         when:
         def result = runTasksSuccessfully('devSnapshot')
+
+        then:
+        def xml = loadIvyFileViaVersionLookup(result)
+        xml.info.@status == 'integration'
+    }
+
+    def 'immutableSnapshot leaves integration status'() {
+        when:
+        def result = runTasksSuccessfully('immutableSnapshot')
 
         then:
         def xml = loadIvyFileViaVersionLookup(result)

--- a/src/integTest/groovy/nebula/plugin/release/SnapshotResolutionIntegrationSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/release/SnapshotResolutionIntegrationSpec.groovy
@@ -1,0 +1,114 @@
+package nebula.plugin.release
+
+import nebula.test.IntegrationTestKitSpec
+import nebula.test.dependencies.DependencyGraphBuilder
+import nebula.test.dependencies.GradleDependencyGenerator
+
+class SnapshotResolutionIntegrationSpec extends IntegrationTestKitSpec {
+
+    def 'choose immutableSnapshot version if no release candidate'() {
+        def graph = new DependencyGraphBuilder()
+                .addModule('test:a:0.0.1')
+                .addModule('test:a:0.0.2-snapshot.20190708102343+23sd')
+                .build()
+        File mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen").generateTestMavenRepo()
+
+        buildFile << """\
+            apply plugin: 'java'
+            repositories {
+                maven { url '${mavenrepo.absolutePath}' }
+            }
+
+
+            dependencies {
+                compile 'test:a:0.+'
+            }
+        """.stripIndent()
+
+        when:
+        def result = runTasks('dependencies')
+
+        then:
+        result.output.contains("test:a:0.+ -> 0.0.2-snapshot.20190708102343+23sd")
+    }
+
+    def 'choose devSnapshot version if no release candidate'() {
+        def graph = new DependencyGraphBuilder()
+                .addModule('test:a:0.0.1')
+                .addModule('test:a:0.0.2-dev.1+23sd')
+                .build()
+        File mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen").generateTestMavenRepo()
+
+        buildFile << """\
+            apply plugin: 'java'
+            repositories {
+                maven { url '${mavenrepo.absolutePath}' }
+            }
+
+
+            dependencies {
+                compile 'test:a:0.+'
+            }
+        """.stripIndent()
+
+        when:
+        def result = runTasks('dependencies')
+
+        then:
+        result.output.contains("test:a:0.+ -> 0.0.2-dev.1+23sd")
+    }
+
+    def 'choose candidate version instead of immutable if release candidate is present'() {
+        def graph = new DependencyGraphBuilder()
+                .addModule('test:a:0.0.1')
+                .addModule('test:a:0.0.2-rc.1')
+                .addModule('test:a:0.0.2-snapshot.20190708102343+23sd')
+                .build()
+        File mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen").generateTestMavenRepo()
+
+        buildFile << """\
+            apply plugin: 'java'
+            repositories {
+                maven { url '${mavenrepo.absolutePath}' }
+            }
+
+
+            dependencies {
+                compile 'test:a:0.+'
+            }
+        """.stripIndent()
+
+        when:
+        def result = runTasks('dependencies')
+
+        then:
+        result.output.contains("test:a:0.+ -> 0.0.2-rc.1")
+    }
+
+    def 'choose candidate version instead of devSnapshot if release candidate is present'() {
+        def graph = new DependencyGraphBuilder()
+                .addModule('test:a:0.0.1')
+                .addModule('test:a:0.0.2-rc.1')
+                .addModule('test:a:0.0.2-rc.1.dev.1+23sd')
+                .build()
+        File mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen").generateTestMavenRepo()
+
+        buildFile << """\
+            apply plugin: 'java'
+            repositories {
+                maven { url '${mavenrepo.absolutePath}' }
+            }
+
+
+            dependencies {
+                compile 'test:a:0.+'
+            }
+        """.stripIndent()
+
+        when:
+        def result = runTasks('dependencies')
+
+        then:
+        result.output.contains("test:a:0.+ -> 0.0.2-rc.1")
+    }
+}

--- a/src/main/groovy/nebula/plugin/release/NetflixOssStrategies.groovy
+++ b/src/main/groovy/nebula/plugin/release/NetflixOssStrategies.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Netflix, Inc.
+ * Copyright 2014-2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,12 @@ class NetflixOssStrategies {
 
     static SemVerStrategy DEVELOPMENT(Project project) {
         Strategies.DEVELOPMENT.copyWith(
+                normalStrategy: getScopes(project),
+                buildMetadataStrategy: BuildMetadata.DEVELOPMENT_METADATA_STRATEGY)
+    }
+
+    static SemVerStrategy IMMUTABLE_SNAPSHOT(Project project) {
+        Strategies.IMMUTABLE_SNAPSHOT.copyWith(
                 normalStrategy: getScopes(project),
                 buildMetadataStrategy: BuildMetadata.DEVELOPMENT_METADATA_STRATEGY)
     }

--- a/src/main/groovy/nebula/plugin/release/OverrideStrategies.groovy
+++ b/src/main/groovy/nebula/plugin/release/OverrideStrategies.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Netflix, Inc.
+ * Copyright 2014-2019 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,16 +71,16 @@ class OverrideStrategies {
             } catch(MissingPropertyException e) {
                 releaseStage = NOT_SUPPLIED
                 logger.debug("ExtraPropertiesExtension 'release.stage' was not supplied", e.getMessage())
-                logger.info("Note: It is recommended to supply a release strategy of <snapshot|devSnapshot|candidate|final> to make 'useLastTag' most explicit. Please add one to your list of tasks.")
+                logger.info("Note: It is recommended to supply a release strategy of <snapshot|immutableSnapshot|devSnapshot|candidate|final> to make 'useLastTag' most explicit. Please add one to your list of tasks.")
             }
 
-            if (releaseStage == 'dev' || releaseStage == 'SNAPSHOT') {
-                throw new GradleException("Cannot use useLastTag with snapshot and devSnapshot tasks")
+            if (releaseStage == 'dev' ||  releaseStage == 'snapshot' || releaseStage == 'SNAPSHOT') {
+                throw new GradleException("Cannot use useLastTag with snapshot, immutableSnapshot and devSnapshot tasks")
             }
 
             if (locate.distanceFromAny == 0) {
-                if(releaseStage == NOT_SUPPLIED && (locate.any.toString().contains('-dev.') || locate.any.toString().contains('-SNAPSHOT'))) {
-                    throw new GradleException("Current commit has a snapshot or devSnapshot tag. 'useLastTag' requires a prerelease or final tag.")
+                if(releaseStage == NOT_SUPPLIED && (locate.any.toString().contains('-dev.') || locate.any.toString().contains('-SNAPSHOT')  || locate.any.toString().contains('-snapshot.') )) {
+                    throw new GradleException("Current commit has a snapshot, immutableSnapshot or devSnapshot tag. 'useLastTag' requires a prerelease or final tag.")
                 }
 
                 def preReleaseVersion = locate.any.preReleaseVersion

--- a/src/main/groovy/nebula/plugin/release/git/opinion/OpinionReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/opinion/OpinionReleasePlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ class OpinionReleasePlugin implements Plugin<Project> {
 
         project.release {
             versionStrategy RebuildVersionStrategy.INSTANCE
+            versionStrategy Strategies.IMMUTABLE_SNAPSHOT
             versionStrategy Strategies.DEVELOPMENT
             versionStrategy Strategies.PRE_RELEASE
             versionStrategy Strategies.FINAL

--- a/src/main/groovy/nebula/plugin/release/git/opinion/TimestampUtil.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/opinion/TimestampUtil.groovy
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nebula.plugin.release.git.opinion
+
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+class TimestampUtil {
+
+    private static DateTimeFormatter timestampDateFormat = DateTimeFormatter
+            .ofPattern("YYYYMMddHHmmssSSS")
+            .withZone(ZoneOffset.UTC)
+
+    static String getUTCFormattedTimestamp() {
+        return LocalDateTime
+                .ofInstant(Instant.now(), ZoneOffset.UTC)
+                .format(timestampDateFormat)
+    }
+}

--- a/src/test/groovy/nebula/plugin/release/git/opinion/OpinionReleasePluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/release/git/opinion/OpinionReleasePluginSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ class OpinionReleasePluginSpec extends Specification {
         given:
         project.plugins.apply(OpinionReleasePlugin)
         expect:
-        project.release.versionStrategies == [RebuildVersionStrategy.INSTANCE, Strategies.DEVELOPMENT, Strategies.PRE_RELEASE, Strategies.FINAL]
+        project.release.versionStrategies == [RebuildVersionStrategy.INSTANCE, Strategies.IMMUTABLE_SNAPSHOT, Strategies.DEVELOPMENT, Strategies.PRE_RELEASE, Strategies.FINAL]
         project.release.defaultVersionStrategy == Strategies.DEVELOPMENT
     }
 

--- a/src/test/groovy/nebula/plugin/release/git/opinion/StrategiesSpec.groovy
+++ b/src/test/groovy/nebula/plugin/release/git/opinion/StrategiesSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2017 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,20 +35,22 @@ import org.gradle.api.Project
 import spock.lang.Specification
 import spock.lang.Unroll
 
+@Unroll
 class StrategiesSpec extends Specification {
     SemVerStrategyState initialState = new SemVerStrategyState([:])
+
     @Unroll('Normal.USE_SCOPE_PROP with scope #scope results in #version')
     def 'Normal.USE_SCOPE_PROP'() {
         def nearestVersion = new NearestVersion(normal: Version.valueOf('1.2.3'))
         def initialState = new SemVerStrategyState(
-            scopeFromProp: scope,
-            nearestVersion: nearestVersion)
+                scopeFromProp: scope,
+                nearestVersion: nearestVersion)
         expect:
         Strategies.Normal.USE_SCOPE_PROP.infer(initialState) ==
-            new SemVerStrategyState(
-                scopeFromProp: scope,
-                nearestVersion: nearestVersion,
-                inferredNormal: version)
+                new SemVerStrategyState(
+                        scopeFromProp: scope,
+                        nearestVersion: nearestVersion,
+                        inferredNormal: version)
         where:
         scope             | version
         ChangeScope.PATCH | '1.2.4'
@@ -59,21 +61,21 @@ class StrategiesSpec extends Specification {
     def 'Normal.USE_NEAREST_ANY with different nearest any and normal uses any\'s normal'() {
         given:
         def nearestVersion = new NearestVersion(
-            any: Version.valueOf('1.2.5-beta.1'),
-            normal: Version.valueOf('1.2.4'))
+                any: Version.valueOf('1.2.5-beta.1'),
+                normal: Version.valueOf('1.2.4'))
         def initialState = new SemVerStrategyState(nearestVersion: nearestVersion)
         expect:
         Strategies.Normal.USE_NEAREST_ANY.infer(initialState) ==
-            new SemVerStrategyState(nearestVersion: nearestVersion, inferredNormal: '1.2.5')
+                new SemVerStrategyState(nearestVersion: nearestVersion, inferredNormal: '1.2.5')
     }
 
 
     def 'Normal.USE_NEAREST_ANY with same nearest any and normal does nothing'() {
         given:
         def initialState = new SemVerStrategyState(
-            nearestVersion: new NearestVersion(
-                any: Version.valueOf('1.2.4'),
-                normal: Version.valueOf('1.2.4')))
+                nearestVersion: new NearestVersion(
+                        any: Version.valueOf('1.2.4'),
+                        normal: Version.valueOf('1.2.4')))
         expect:
         Strategies.Normal.USE_NEAREST_ANY.infer(initialState) == initialState
     }
@@ -81,8 +83,8 @@ class StrategiesSpec extends Specification {
     def 'Normal.ENFORCE_BRANCH_MAJOR_X fails if nearest normal can\'t be incremented to something that complies with branch'() {
         given:
         def initialState = new SemVerStrategyState(
-            nearestVersion: new NearestVersion(normal: Version.valueOf('1.2.3')),
-            currentBranch: new Branch(fullName: 'refs/heads/3.x'))
+                nearestVersion: new NearestVersion(normal: Version.valueOf('1.2.3')),
+                currentBranch: new Branch(fullName: 'refs/heads/3.x'))
         when:
         Strategies.Normal.ENFORCE_BRANCH_MAJOR_X.infer(initialState)
         then:
@@ -94,11 +96,11 @@ class StrategiesSpec extends Specification {
     def 'Normal.ENFORCE_BRANCH_MAJOR_X correctly increments version to comply with branch'() {
         given:
         def initialState = new SemVerStrategyState(
-            nearestVersion: new NearestVersion(normal: Version.valueOf(nearest)),
-            currentBranch: new Branch(fullName: 'refs/heads/3.x'))
+                nearestVersion: new NearestVersion(normal: Version.valueOf(nearest)),
+                currentBranch: new Branch(fullName: 'refs/heads/3.x'))
         expect:
         Strategies.Normal.ENFORCE_BRANCH_MAJOR_X.infer(initialState) ==
-            initialState.copyWith(inferredNormal: inferred)
+                initialState.copyWith(inferredNormal: inferred)
         where:
         nearest | inferred
         '2.0.0' | '3.0.0'
@@ -112,13 +114,13 @@ class StrategiesSpec extends Specification {
     def 'Normal.ENFORCE_GITFLOW_BRANCH_MAJOR_X correctly increments version to comply with branch'() {
         given:
         def initialState = new SemVerStrategyState(
-            nearestVersion: new NearestVersion(normal: Version.valueOf(nearest)),
-            currentBranch: new Branch(fullName: "refs/heads/${branchName}"))
+                nearestVersion: new NearestVersion(normal: Version.valueOf(nearest)),
+                currentBranch: new Branch(fullName: "refs/heads/${branchName}"))
         expect:
         Strategies.Normal.ENFORCE_GITFLOW_BRANCH_MAJOR_X.infer(initialState) ==
-            initialState.copyWith(inferredNormal: inferred)
+                initialState.copyWith(inferredNormal: inferred)
         where:
-        branchName        | nearest | inferred
+        branchName    | nearest | inferred
         'release/3.x' | '2.0.0' | '3.0.0'
         'release-3.x' | '2.3.4' | '3.0.0'
         'release-3.x' | '3.0.0' | null
@@ -128,8 +130,8 @@ class StrategiesSpec extends Specification {
     def 'Normal.ENFORCE_BRANCH_MAJOR_MINOR_X fails if nearest normal can\'t be incremented to something that complies with branch'() {
         given:
         def initialState = new SemVerStrategyState(
-            nearestVersion: new NearestVersion(normal: Version.valueOf(version)),
-            currentBranch: new Branch(fullName: 'refs/heads/3.2.x'))
+                nearestVersion: new NearestVersion(normal: Version.valueOf(version)),
+                currentBranch: new Branch(fullName: 'refs/heads/3.2.x'))
         when:
         Strategies.Normal.ENFORCE_BRANCH_MAJOR_MINOR_X.infer(initialState)
         then:
@@ -141,34 +143,34 @@ class StrategiesSpec extends Specification {
     def 'Normal.ENFORCE_BRANCH_MAJOR_MINOR_X correctly increments version to comply with branch'() {
         given:
         def initialState = new SemVerStrategyState(
-            nearestVersion: new NearestVersion(normal: Version.valueOf(nearest)),
-            currentBranch: new Branch(fullName: "refs/heads/${branchName}"))
+                nearestVersion: new NearestVersion(normal: Version.valueOf(nearest)),
+                currentBranch: new Branch(fullName: "refs/heads/${branchName}"))
         expect:
         Strategies.Normal.ENFORCE_BRANCH_MAJOR_MINOR_X.infer(initialState) ==
-            initialState.copyWith(inferredNormal: inferred)
+                initialState.copyWith(inferredNormal: inferred)
         where:
-        branchName  | nearest | inferred
-        '3.0.x' | '2.0.0' | '3.0.0'
-        '3.0.x' | '2.1.0' | '3.0.0'
-        '3.0.x' | '2.1.2' | '3.0.0'
-        '3.0.x' | '3.0.0' | '3.0.1'
-        '3.0.x' | '3.0.1' | '3.0.2'
-        '3.2.x' | '3.1.0' | '3.2.0'
-        '3.2.x' | '3.1.2' | '3.2.0'
-        '3.2.x' | '3.2.0' | '3.2.1'
-        '3.2.x' | '3.2.1' | '3.2.2'
+        branchName | nearest | inferred
+        '3.0.x'    | '2.0.0' | '3.0.0'
+        '3.0.x'    | '2.1.0' | '3.0.0'
+        '3.0.x'    | '2.1.2' | '3.0.0'
+        '3.0.x'    | '3.0.0' | '3.0.1'
+        '3.0.x'    | '3.0.1' | '3.0.2'
+        '3.2.x'    | '3.1.0' | '3.2.0'
+        '3.2.x'    | '3.1.2' | '3.2.0'
+        '3.2.x'    | '3.2.0' | '3.2.1'
+        '3.2.x'    | '3.2.1' | '3.2.2'
     }
 
     def 'Normal.ENFORCE_GITFLOW_BRANCH_MAJOR_MINOR_X correctly increments version to comply with branch'() {
         given:
         def initialState = new SemVerStrategyState(
-            nearestVersion: new NearestVersion(normal: Version.valueOf(nearest)),
-            currentBranch: new Branch(fullName: "refs/heads/${branchName}"))
+                nearestVersion: new NearestVersion(normal: Version.valueOf(nearest)),
+                currentBranch: new Branch(fullName: "refs/heads/${branchName}"))
         expect:
         Strategies.Normal.ENFORCE_GITFLOW_BRANCH_MAJOR_MINOR_X.infer(initialState) ==
-            initialState.copyWith(inferredNormal: inferred)
+                initialState.copyWith(inferredNormal: inferred)
         where:
-        branchName          | nearest | inferred
+        branchName      | nearest | inferred
         'release/3.0.x' | '2.0.0' | '3.0.0'
         'release-3.0.x' | '3.0.0' | '3.0.1'
         'release-3.2.x' | '3.1.2' | '3.2.0'
@@ -178,34 +180,34 @@ class StrategiesSpec extends Specification {
     def 'Normal.ENFORCE_BRANCH_MAJOR_MINOR_X correctly increments version to comply with branch if normalStrategy is to increment minor instead of patch'() {
         given:
         def initialState = new SemVerStrategyState(
-            nearestVersion: new NearestVersion(normal: Version.valueOf(nearest)),
-            currentBranch: new Branch(fullName: "refs/heads/${branchName}"))
+                nearestVersion: new NearestVersion(normal: Version.valueOf(nearest)),
+                currentBranch: new Branch(fullName: "refs/heads/${branchName}"))
         def strategy = StrategyUtil.one(Strategies.Normal.ENFORCE_BRANCH_MAJOR_MINOR_X, Strategies.Normal.useScope(ChangeScope.MINOR))
         expect:
         strategy.infer(initialState) == initialState.copyWith(inferredNormal: inferred)
         where:
-        branchName  | nearest | inferred
-        '3.0.x' | '2.0.0' | '3.0.0'
-        '3.0.x' | '2.1.0' | '3.0.0'
-        '3.0.x' | '2.1.2' | '3.0.0'
-        '3.0.x' | '3.0.0' | '3.0.1'
-        '3.0.x' | '3.0.1' | '3.0.2'
-        '3.2.x' | '3.1.0' | '3.2.0'
-        '3.2.x' | '3.1.2' | '3.2.0'
-        '3.2.x' | '3.2.0' | '3.2.1'
-        '3.2.x' | '3.2.1' | '3.2.2'
+        branchName | nearest | inferred
+        '3.0.x'    | '2.0.0' | '3.0.0'
+        '3.0.x'    | '2.1.0' | '3.0.0'
+        '3.0.x'    | '2.1.2' | '3.0.0'
+        '3.0.x'    | '3.0.0' | '3.0.1'
+        '3.0.x'    | '3.0.1' | '3.0.2'
+        '3.2.x'    | '3.1.0' | '3.2.0'
+        '3.2.x'    | '3.1.2' | '3.2.0'
+        '3.2.x'    | '3.2.0' | '3.2.1'
+        '3.2.x'    | '3.2.1' | '3.2.2'
     }
 
     def 'Normal.ENFORCE_GITFLOW_BRANCH_MAJOR_MINOR_X correctly increments version to comply with branch if normalStrategy is to increment minor instead of patch'() {
         given:
         def initialState = new SemVerStrategyState(
-            nearestVersion: new NearestVersion(normal: Version.valueOf(nearest)),
-            currentBranch: new Branch(fullName: "refs/heads/${branchName}"))
+                nearestVersion: new NearestVersion(normal: Version.valueOf(nearest)),
+                currentBranch: new Branch(fullName: "refs/heads/${branchName}"))
         def strategy = StrategyUtil.one(Strategies.Normal.ENFORCE_GITFLOW_BRANCH_MAJOR_MINOR_X, Strategies.Normal.useScope(ChangeScope.MINOR))
         expect:
         strategy.infer(initialState) == initialState.copyWith(inferredNormal: inferred)
         where:
-        branchName          | nearest | inferred
+        branchName      | nearest | inferred
         'release/3.0.x' | '2.0.0' | '3.0.0'
         'release-3.0.x' | '3.0.0' | '3.0.1'
         'release-3.2.x' | '3.1.2' | '3.2.0'
@@ -215,7 +217,7 @@ class StrategiesSpec extends Specification {
     def 'Normal.useScope correctly increments normal'() {
         given:
         def initialState = new SemVerStrategyState(
-            nearestVersion: new NearestVersion(normal: Version.valueOf('1.2.3')))
+                nearestVersion: new NearestVersion(normal: Version.valueOf('1.2.3')))
         expect:
         Strategies.Normal.useScope(scope).infer(initialState) == initialState.copyWith(inferredNormal: inferred)
         where:
@@ -233,8 +235,8 @@ class StrategiesSpec extends Specification {
     def 'PreRelease.STAGE_FIXED always replaces inferredPreRelease with stageFromProp'() {
         given:
         def initialState = new SemVerStrategyState(
-            stageFromProp: 'boom',
-            inferredPreRelease: initialPreRelease)
+                stageFromProp: 'boom',
+                inferredPreRelease: initialPreRelease)
         expect:
         Strategies.PreRelease.STAGE_FIXED.infer(initialState) == initialState.copyWith(inferredPreRelease: 'boom')
         where:
@@ -244,12 +246,12 @@ class StrategiesSpec extends Specification {
     def 'PreRelease.STAGE_FLOAT will append the stageFromProp to the nearest any\'s pre release, if any, unless it has higher precedence'() {
         given:
         def initialState = new SemVerStrategyState(
-            stageFromProp: 'boom',
-            inferredNormal: '1.1.0',
-            inferredPreRelease: 'other',
-            nearestVersion: new NearestVersion(
-                normal: Version.valueOf('1.0.0'),
-                any: Version.valueOf(nearest)))
+                stageFromProp: 'boom',
+                inferredNormal: '1.1.0',
+                inferredPreRelease: 'other',
+                nearestVersion: new NearestVersion(
+                        normal: Version.valueOf('1.0.0'),
+                        any: Version.valueOf(nearest)))
         expect:
         Strategies.PreRelease.STAGE_FLOAT.infer(initialState) == initialState.copyWith(inferredPreRelease: expected)
         where:
@@ -264,11 +266,11 @@ class StrategiesSpec extends Specification {
     def 'PreRelease.COUNT_INCREMENTED will increment the nearest any\'s pre release or set to 1 if not found'() {
         given:
         def initialState = new SemVerStrategyState(
-            inferredNormal: '1.1.0',
-            inferredPreRelease: initialPreRelease,
-            nearestVersion: new NearestVersion(
-                normal: Version.valueOf('1.0.0'),
-                any: Version.valueOf(nearestAny)))
+                inferredNormal: '1.1.0',
+                inferredPreRelease: initialPreRelease,
+                nearestVersion: new NearestVersion(
+                        normal: Version.valueOf('1.0.0'),
+                        any: Version.valueOf(nearestAny)))
         expect:
         Strategies.PreRelease.COUNT_INCREMENTED.infer(initialState) == initialState.copyWith(inferredPreRelease: expected)
         where:
@@ -289,8 +291,8 @@ class StrategiesSpec extends Specification {
     def 'PreRelease.COUNT_COMMITS_SINCE_ANY will append distanceFromAny'() {
         given:
         def initialState = new SemVerStrategyState(
-            inferredPreRelease: initialPreRelease,
-            nearestVersion: new NearestVersion(distanceFromAny: distance))
+                inferredPreRelease: initialPreRelease,
+                nearestVersion: new NearestVersion(distanceFromAny: distance))
         expect:
         Strategies.PreRelease.COUNT_COMMITS_SINCE_ANY.infer(initialState) == initialState.copyWith(inferredPreRelease: expected)
         where:
@@ -304,8 +306,8 @@ class StrategiesSpec extends Specification {
     def 'PreRelease.SHOW_UNCOMMITTED appends uncommitted only if repo is dirty'() {
         given:
         def initialState = new SemVerStrategyState(
-            inferredPreRelease: initialPreRelease,
-            repoDirty: dirty)
+                inferredPreRelease: initialPreRelease,
+                repoDirty: dirty)
         expect:
         Strategies.PreRelease.SHOW_UNCOMMITTED.infer(initialState) == initialState.copyWith(inferredPreRelease: expected)
         where:
@@ -339,7 +341,7 @@ class StrategiesSpec extends Specification {
         def initialState = new SemVerStrategyState(currentHead: new Commit(id: id))
         expect:
         Strategies.BuildMetadata.COMMIT_FULL_ID.infer(initialState) ==
-            initialState.copyWith(inferredBuildMetadata: id)
+                initialState.copyWith(inferredBuildMetadata: id)
     }
 
     def 'BuildMetadata.TIMESTAMP uses current time'() {
@@ -376,15 +378,38 @@ class StrategiesSpec extends Specification {
         expect:
         Strategies.DEVELOPMENT.doInfer(project, grgit, locator) == new ReleaseVersion(expected, nearestNormal, false)
         where:
+        scope   | stage | nearestNormal | nearestAny      | repoDirty | expected
+        null    | null  | '1.0.0'       | '1.0.0'         | false     | '1.0.1-dev.2+5e9b2a1'
+        null    | null  | '1.0.0'       | '1.0.0'         | true      | '1.0.1-dev.2.uncommitted+5e9b2a1'
+        null    | null  | '1.0.0'       | '1.1.0-alpha.1' | false     | '1.1.0-dev.2+5e9b2a1'
+        null    | null  | '1.0.0'       | '1.1.0-rc.3'    | false     | '1.1.0-rc.3.dev.2+5e9b2a1'
+        null    | null  | '1.0.0'       | '1.1.0-rc.3'    | true      | '1.1.0-rc.3.dev.2.uncommitted+5e9b2a1'
+        'PATCH' | 'dev' | '1.0.0'       | '1.0.0'         | false     | '1.0.1-dev.2+5e9b2a1'
+        'MINOR' | 'dev' | '1.0.0'       | '1.0.0'         | false     | '1.1.0-dev.2+5e9b2a1'
+        'MAJOR' | 'dev' | '1.0.0'       | '1.0.0'         | false     | '2.0.0-dev.2+5e9b2a1'
+    }
+
+    def 'IMMUTABLE_SNAPSHOT works as expected'() {
+        given:
+        def project = mockProject(scope, stage)
+        def grgit = mockGrgit(repoDirty)
+        def locator = mockLocator(nearestNormal, nearestAny)
+        GroovyMock(TimestampUtil, global: true)
+        TimestampUtil.getUTCFormattedTimestamp() >> '20190705103502'
+
+        expect:
+        Strategies.IMMUTABLE_SNAPSHOT.doInfer(project, grgit, locator) == new ReleaseVersion(expected, nearestNormal, false)
+
+        where:
         scope   | stage      | nearestNormal | nearestAny      | repoDirty | expected
-        null    | null       | '1.0.0'       | '1.0.0'         | false     | '1.0.1-dev.2+5e9b2a1'
-        null    | null       | '1.0.0'       | '1.0.0'         | true      | '1.0.1-dev.2.uncommitted+5e9b2a1'
-        null    | null       | '1.0.0'       | '1.1.0-alpha.1' | false     | '1.1.0-dev.2+5e9b2a1'
-        null    | null       | '1.0.0'       | '1.1.0-rc.3'    | false     | '1.1.0-rc.3.dev.2+5e9b2a1'
-        null    | null       | '1.0.0'       | '1.1.0-rc.3'    | true      | '1.1.0-rc.3.dev.2.uncommitted+5e9b2a1'
-        'PATCH' | 'dev'      | '1.0.0'       | '1.0.0'         | false     | '1.0.1-dev.2+5e9b2a1'
-        'MINOR' | 'dev'      | '1.0.0'       | '1.0.0'         | false     | '1.1.0-dev.2+5e9b2a1'
-        'MAJOR' | 'dev'      | '1.0.0'       | '1.0.0'         | false     | '2.0.0-dev.2+5e9b2a1'
+        null    | null       | '1.0.0'       | '1.0.0'         | false     | '1.0.1-snapshot.20190705103502+5e9b2a1'
+        null    | null       | '1.0.0'       | '1.0.0'         | true      | '1.0.1-snapshot.20190705103502.uncommitted+5e9b2a1'
+        null    | null       | '1.0.0'       | '1.1.0-alpha.1' | false     | '1.1.0-snapshot.20190705103502+5e9b2a1'
+        null    | null       | '1.0.0'       | '1.1.0-rc.3'    | false     | '1.1.0-snapshot.20190705103502+5e9b2a1'
+        null    | null       | '1.0.0'       | '1.1.0-rc.3'    | true      | '1.1.0-snapshot.20190705103502.uncommitted+5e9b2a1'
+        'PATCH' | 'snapshot' | '1.0.0'       | '1.0.0'         | false     | '1.0.1-snapshot.20190705103502+5e9b2a1'
+        'MINOR' | 'snapshot' | '1.0.0'       | '1.0.0'         | false     | '1.1.0-snapshot.20190705103502+5e9b2a1'
+        'MAJOR' | 'snapshot' | '1.0.0'       | '1.0.0'         | false     | '2.0.0-snapshot.20190705103502+5e9b2a1'
     }
 
     def 'PRE_RELEASE works as expected'() {
@@ -414,13 +439,13 @@ class StrategiesSpec extends Specification {
         expect:
         Strategies.FINAL.doInfer(project, grgit, locator) == new ReleaseVersion(expected, nearestNormal, true)
         where:
-        scope   | stage       | nearestNormal | nearestAny          | repoDirty | expected
-        null    | null        | '1.0.0'       | '1.0.0'             | false     | '1.0.1'
-        'PATCH' | null        | '1.0.0'       | '1.0.0'             | false     | '1.0.1'
-        'MINOR' | null        | '1.0.0'       | '1.0.0'             | false     | '1.1.0'
-        'MAJOR' | null        | '1.0.0'       | '1.0.0'             | false     | '2.0.0'
-        'MAJOR' | 'final'     | '1.0.0'       | '1.0.0'             | false     | '2.0.0'
-        'MINOR' | 'final'     | '1.0.0'       | '1.1.0-alpha.2'     | false     | '1.1.0'
+        scope   | stage   | nearestNormal | nearestAny      | repoDirty | expected
+        null    | null    | '1.0.0'       | '1.0.0'         | false     | '1.0.1'
+        'PATCH' | null    | '1.0.0'       | '1.0.0'         | false     | '1.0.1'
+        'MINOR' | null    | '1.0.0'       | '1.0.0'         | false     | '1.1.0'
+        'MAJOR' | null    | '1.0.0'       | '1.0.0'         | false     | '2.0.0'
+        'MAJOR' | 'final' | '1.0.0'       | '1.0.0'         | false     | '2.0.0'
+        'MINOR' | 'final' | '1.0.0'       | '1.1.0-alpha.2' | false     | '1.1.0'
     }
 
     def 'PRE_RELEASE_ALPHA_BETA works as expected'() {
@@ -430,21 +455,21 @@ class StrategiesSpec extends Specification {
         expect:
         Strategies.PRE_RELEASE_ALPHA_BETA.doInfer(project, grgit, locator) == new ReleaseVersion(expected, nearestNormal, true)
         where:
-        scope   | stage       | nearestNormal | nearestAny          | repoDirty | expected
-        null    | null        | '1.0.0'       | '1.0.0'             | false     | '1.0.1-alpha.1'
-        null    | 'alpha'     | '1.0.0'       | '1.0.0'             | false     | '1.0.1-alpha.1'
-        null    | 'beta'      | '1.0.0'       | '1.0.0'             | false     | '1.0.1-beta.1'
-        null    | 'rc'        | '1.0.0'       | '1.0.0'             | false     | '1.0.1-rc.1'
-        'PATCH' | 'alpha'     | '1.0.0'       | '1.0.0'             | false     | '1.0.1-alpha.1'
-        'MINOR' | 'alpha'     | '1.0.0'       | '1.0.0'             | false     | '1.1.0-alpha.1'
-        'MAJOR' | 'alpha'     | '1.0.0'       | '1.0.0'             | false     | '2.0.0-alpha.1'
-        'PATCH' | 'beta'      | '1.0.0'       | '1.0.0'             | false     | '1.0.1-beta.1'
-        'MINOR' | 'beta'      | '1.0.0'       | '1.0.0'             | false     | '1.1.0-beta.1'
-        'MAJOR' | 'beta'      | '1.0.0'       | '1.0.0'             | false     | '2.0.0-beta.1'
-        null    | 'rc'        | '1.0.0'       | '1.1.0-beta.1'      | false     | '1.1.0-rc.1'
-        null    | 'beta'      | '1.0.0'       | '1.1.0-beta.1'      | false     | '1.1.0-beta.2'
-        null    | 'rc'        | '1.0.0'       | '1.1.0-rc'          | false     | '1.1.0-rc.1'
-        null    | 'rc'        | '1.0.0'       | '1.1.0-rc.4.dev.1'  | false     | '1.1.0-rc.5'
+        scope   | stage   | nearestNormal | nearestAny         | repoDirty | expected
+        null    | null    | '1.0.0'       | '1.0.0'            | false     | '1.0.1-alpha.1'
+        null    | 'alpha' | '1.0.0'       | '1.0.0'            | false     | '1.0.1-alpha.1'
+        null    | 'beta'  | '1.0.0'       | '1.0.0'            | false     | '1.0.1-beta.1'
+        null    | 'rc'    | '1.0.0'       | '1.0.0'            | false     | '1.0.1-rc.1'
+        'PATCH' | 'alpha' | '1.0.0'       | '1.0.0'            | false     | '1.0.1-alpha.1'
+        'MINOR' | 'alpha' | '1.0.0'       | '1.0.0'            | false     | '1.1.0-alpha.1'
+        'MAJOR' | 'alpha' | '1.0.0'       | '1.0.0'            | false     | '2.0.0-alpha.1'
+        'PATCH' | 'beta'  | '1.0.0'       | '1.0.0'            | false     | '1.0.1-beta.1'
+        'MINOR' | 'beta'  | '1.0.0'       | '1.0.0'            | false     | '1.1.0-beta.1'
+        'MAJOR' | 'beta'  | '1.0.0'       | '1.0.0'            | false     | '2.0.0-beta.1'
+        null    | 'rc'    | '1.0.0'       | '1.1.0-beta.1'     | false     | '1.1.0-rc.1'
+        null    | 'beta'  | '1.0.0'       | '1.1.0-beta.1'     | false     | '1.1.0-beta.2'
+        null    | 'rc'    | '1.0.0'       | '1.1.0-rc'         | false     | '1.1.0-rc.1'
+        null    | 'rc'    | '1.0.0'       | '1.1.0-rc.4.dev.1' | false     | '1.1.0-rc.5'
     }
 
     def mockProject(String scope, String stage) {
@@ -478,10 +503,10 @@ class StrategiesSpec extends Specification {
     def mockLocator(String nearestNormal, String nearestAny) {
         NearestVersionLocator locator = Mock()
         locator.locate(_) >> new NearestVersion(
-            normal: Version.valueOf(nearestNormal),
-            distanceFromNormal: 5,
-            any: Version.valueOf(nearestAny),
-            distanceFromAny: 2
+                normal: Version.valueOf(nearestNormal),
+                distanceFromNormal: 5,
+                any: Version.valueOf(nearestAny),
+                distanceFromAny: 2
         )
         return locator
     }


### PR DESCRIPTION
This introduces `immutableSnapshot` task/strategy to generate snapshot versions that are meant to be immutable and should be unique via UTC timestamp. Ex. `1.2.0-snapshot.20190705210556893+abcdef`  

Pattern is  `<major>.<minor>.<patch>-snapshot.<timestamp>+<hash>` and timestamp format is `YYYYMMddHHmmssSSS`

This change doesn't replace `devSnapshot` and default strategy to prevent breaking changes for consumers.

We should be able to override the default strategy from `devSnapshot` to `immutableSnapshot` via `ReleasePluginExtension`:

```
release {
                defaultVersionStrategy = nebula.plugin.release.NetflixOssStrategies.IMMUTABLE_SNAPSHOT(project)
            }
``` 

