### PR TITLE
Introduce feature flag to replace devSnapshot with immutableSnapshot under the hood

### DIFF
--- a/src/main/groovy/nebula/plugin/release/FeatureFlags.groovy
+++ b/src/main/groovy/nebula/plugin/release/FeatureFlags.groovy
@@ -1,0 +1,13 @@
+package nebula.plugin.release
+
+import groovy.transform.CompileStatic
+import org.gradle.api.Project
+
+@CompileStatic
+class FeatureFlags {
+    public static final String NEBULA_RELEASE_REPLACE_DEV_SNAPSHOT_WITH_IMMUTABLE_SNAPSHOT = "nebula.release.features.replaceDevWithImmutableSnapshot"
+
+    static boolean isDevSnapshotReplacementEnabled(Project project) {
+        return project.findProperty(NEBULA_RELEASE_REPLACE_DEV_SNAPSHOT_WITH_IMMUTABLE_SNAPSHOT)?.toString()?.toBoolean()
+    }
+}

--- a/src/main/groovy/nebula/plugin/release/OverrideStrategies.groovy
+++ b/src/main/groovy/nebula/plugin/release/OverrideStrategies.groovy
@@ -18,6 +18,7 @@ package nebula.plugin.release
 import nebula.plugin.release.git.base.ReleasePluginExtension
 import nebula.plugin.release.git.base.ReleaseVersion
 import nebula.plugin.release.git.base.VersionStrategy
+import nebula.plugin.release.git.opinion.TimestampUtil
 import nebula.plugin.release.git.semver.NearestVersionLocator
 import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.Tag
@@ -170,7 +171,12 @@ class OverrideStrategies {
 
         @Override
         ReleaseVersion infer(Project project, Grgit grgit) {
-            new ReleaseVersion('0.1.0-dev.0.uncommitted', null, false)
+            boolean replaceDevSnapshots = FeatureFlags.isDevSnapshotReplacementEnabled(project)
+            if(replaceDevSnapshots) {
+                new ReleaseVersion("0.1.0-snapshot.${TimestampUtil.getUTCFormattedTimestamp()}.uncommitted", null, false)
+            } else {
+                new ReleaseVersion('0.1.0-dev.0.uncommitted', null, false)
+            }
         }
     }
 


### PR DESCRIPTION
This is for people trying to leverage `immutableSnapshot` without the need of re-writing infrastructure that uses `devSnapshot` task.

Unfortunately, modifying task configuration in consumers isn't enough. Ex.

```
            TaskContainer tasksContainer = project.rootProject.tasks
            Task devSnapshot = tasksContainer.findByName('devSnapshot')
            Task immutableSnapshot = tasksContainer.findByName('immutableSnapshot')

            if(!immutableSnapshot || !devSnapshot) {
                logger.debug("immutableSnapshot and/or devSnapshot tasks are not present. Skipping immutable snapshot configuration")
                return
            }

            devSnapshot.dependsOn(immutableSnapshot)
            devSnapshot.enabled = false
```

While this instructs Gradle to execute `immutableSnapshot` task and disable `devSnapshot` this doesn't work as expected.

This is because release plugin uses the tasks that were invoked to determine the intention and execute the proper stage -> https://github.com/nebula-plugins/nebula-release-plugin/blob/master/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy#L193 

At this point, the plugin is only aware of the `devSnapshot` intent because that's what's coming from `cliTasks`. 

To avoid a refactor around this, I propose adding this feature flag that changes the stage under the hood for `devSnapshot`, leveraging the `immutableSnapshot` stage instead. This way, consumers of the plugin could migrate by just adding a feature flag on their distribution instead of asking everyone to migrate tasks on their tooling