### PR TITLE
devSnapshot - remove attaching of STAGE_FLOAT

### DIFF
--- a/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
@@ -138,7 +138,7 @@ class ReleasePluginIntegrationSpec extends GitVersioningIntegrationSpec {
         def version = inferredVersionForTask('devSnapshot')
 
         then:
-        version == dev('2.2.0-rc.1.dev.0+')
+        version == dev('2.2.0-dev.0+')
     }
 
     def 'choose no rc in snapshot version'() {

--- a/src/main/groovy/nebula/plugin/release/git/opinion/Strategies.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/opinion/Strategies.groovy
@@ -198,13 +198,7 @@ final class Strategies {
          * to the nearest any's pre-release.
          */
         static final PartialSemVerStrategy STAGE_FLOAT = closure { state ->
-            def sameNormal = state.inferredNormal == state.nearestVersion.any.normalVersion
-            def nearestAnyPreRelease = state.nearestVersion.any.preReleaseVersion
-            if (sameNormal && nearestAnyPreRelease != null && (nearestAnyPreRelease > state.stageFromProp)) {
-                state.copyWith(inferredPreRelease: "${nearestAnyPreRelease}.${state.stageFromProp}")
-            } else {
-                state.copyWith(inferredPreRelease: state.stageFromProp)
-            }
+            state.copyWith(inferredPreRelease: state.stageFromProp)
         }
 
         /**
@@ -330,7 +324,8 @@ final class Strategies {
             allowDirtyRepo: true,
             preReleaseStrategy: all(PreRelease.STAGE_FLOAT, PreRelease.COUNT_COMMITS_SINCE_ANY, PreRelease.SHOW_UNCOMMITTED),
             buildMetadataStrategy: BuildMetadata.COMMIT_ABBREVIATED_ID,
-            createTag: false
+            createTag: false,
+            enforcePrecedence: false
     )
 
     /**

--- a/src/test/groovy/nebula/plugin/release/git/opinion/StrategiesSpec.groovy
+++ b/src/test/groovy/nebula/plugin/release/git/opinion/StrategiesSpec.groovy
@@ -243,25 +243,7 @@ class StrategiesSpec extends Specification {
         initialPreRelease << [null, 'other']
     }
 
-    def 'PreRelease.STAGE_FLOAT will append the stageFromProp to the nearest any\'s pre release, if any, unless it has higher precedence'() {
-        given:
-        def initialState = new SemVerStrategyState(
-                stageFromProp: 'boom',
-                inferredNormal: '1.1.0',
-                inferredPreRelease: 'other',
-                nearestVersion: new NearestVersion(
-                        normal: Version.valueOf('1.0.0'),
-                        any: Version.valueOf(nearest)))
-        expect:
-        Strategies.PreRelease.STAGE_FLOAT.infer(initialState) == initialState.copyWith(inferredPreRelease: expected)
-        where:
-        nearest                    | expected
-        '1.0.0'                    | 'boom'
-        '1.0.1-cat.something.else' | 'boom'
-        '1.1.0-and.1'              | 'boom'
-        '1.1.0-cat.1'              | 'cat.1.boom'
-        '1.1.0-cat.something.else' | 'cat.something.else.boom'
-    }
+
 
     def 'PreRelease.COUNT_INCREMENTED will increment the nearest any\'s pre release or set to 1 if not found'() {
         given:
@@ -382,8 +364,8 @@ class StrategiesSpec extends Specification {
         null    | null  | '1.0.0'       | '1.0.0'         | false     | '1.0.1-dev.2+5e9b2a1'
         null    | null  | '1.0.0'       | '1.0.0'         | true      | '1.0.1-dev.2.uncommitted+5e9b2a1'
         null    | null  | '1.0.0'       | '1.1.0-alpha.1' | false     | '1.1.0-dev.2+5e9b2a1'
-        null    | null  | '1.0.0'       | '1.1.0-rc.3'    | false     | '1.1.0-rc.3.dev.2+5e9b2a1'
-        null    | null  | '1.0.0'       | '1.1.0-rc.3'    | true      | '1.1.0-rc.3.dev.2.uncommitted+5e9b2a1'
+        null    | null  | '1.0.0'       | '1.1.0-rc.3'    | false     | '1.1.0-dev.2+5e9b2a1'
+        null    | null  | '1.0.0'       | '1.1.0-rc.3'    | true      | '1.1.0-dev.2.uncommitted+5e9b2a1'
         'PATCH' | 'dev' | '1.0.0'       | '1.0.0'         | false     | '1.0.1-dev.2+5e9b2a1'
         'MINOR' | 'dev' | '1.0.0'       | '1.0.0'         | false     | '1.1.0-dev.2+5e9b2a1'
         'MAJOR' | 'dev' | '1.0.0'       | '1.0.0'         | false     | '2.0.0-dev.2+5e9b2a1'


### PR DESCRIPTION
This is a proposal for fixing the case where generating candidate results in `1.0.0-rc.1` and next `devSnapshot` will be come `1.0.0-rc.1.dev.3...`

Ideally it should be ``1.0.0.dev.3...` as you continue snapshots on the same major/minor/patch

Per @rspieldenner comments:

```
I would expect a candidate producing 2.1.0-rc.2 and then a devSnapshot would return to 2.1.0-dev.#+hash
``` 

This is a breaking change 