### PR TITLE
Introduce checkRemoteBranchOnRelease in ReleaseExtension to disable prepare task

### DIFF
--- a/src/main/groovy/nebula/plugin/release/ReleaseExtension.groovy
+++ b/src/main/groovy/nebula/plugin/release/ReleaseExtension.groovy
@@ -28,6 +28,8 @@ class ReleaseExtension {
 
     Boolean allowReleaseFromDetached = false
 
+    Boolean checkRemoteBranchOnRelease = false
+
     void addReleaseBranchPattern(String pattern) {
         releaseBranchPatterns.add(pattern)
     }

--- a/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
@@ -169,6 +169,13 @@ class ReleasePlugin implements Plugin<Project> {
             if (shouldSkipGitChecks()) {
                 removeReleaseAndPrepLogic(project)
             }
+
+            project.gradle.taskGraph.whenReady { TaskExecutionGraph g ->
+                if(!nebulaReleaseExtension.checkRemoteBranchOnRelease) {
+                    removePrepLogic(project)
+                }
+            }
+
         } else {
             project.version = project.rootProject.version
         }
@@ -192,7 +199,15 @@ class ReleasePlugin implements Plugin<Project> {
     }
 
     private void removeReleaseAndPrepLogic(Project project) {
+        removeReleaseLogic(project)
+        removePrepLogic(project)
+    }
+
+    private void removeReleaseLogic(Project project) {
         project.tasks.getByName('release').enabled = false
+    }
+
+    private void removePrepLogic(Project project) {
         project.tasks.getByName('prepare').enabled = false
     }
 


### PR DESCRIPTION
The idea of this is to disable `prepare` by default and opt-in by setting `checkRemoteBranchOnRelease` at extension level.

The rationale for this is to allow continuous delivery where a user might change the branch when an existing release is happening. `prepare` fails builds if the branch is behind (https://github.com/nebula-plugins/nebula-release-plugin/blob/4c4f364547ac093f7a1acb22644d4f4654cf0bb4/src/main/groovy/nebula/plugin/release/git/base/BaseReleasePlugin.groovy#L89) 

NOTE: this doesn't disable the `release` task as that might have different outputs 
