### PR TITLE
Try using last tag when -Prelease.tryUsingLastTag=true is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ provide the release.useLastTag project property, e.g.
 
     git tag v1.0.0
     ./gradlew -Prelease.useLastTag=true final
+    
+The build will fail if the current commit does not have a tag name following the versioning scheme. If you want to use the tag name if available and otherwise fallback to the default versioning strategy, you may provide the release.tryUsingLastTag project property, e.g.
+
+    ./gradlew -Prelease.tryUsingLastTag=true build
 
 # Overriding version from the command line
 

--- a/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
@@ -849,6 +849,28 @@ class ReleasePluginIntegrationSpec extends GitVersioningIntegrationSpec {
         then:
         new File(projectDir, "build/libs/${moduleName}-19.71.1.jar").exists()
     }
+    def 'try using last tag on tagged version succeeds'() {
+        git.tag.add(name: 'v42.5.3')
+
+        when:
+        runTasksSuccessfully('final', '-Prelease.tryUsingLastTag=true')
+
+        then:
+        new File(projectDir, "build/libs/${moduleName}-42.5.3.jar").exists()
+    }
+
+    def 'tryUsingLastTag not on tagged version succeeds with fallback to default strategy'() {
+        git.tag.add(name: 'v42.5.3')
+        new File(projectDir, "foo").text = "Hi"
+        git.add(patterns: ['foo'] as Set)
+        git.commit(message: 'Something got committed')
+
+        when:
+        def version = inferredVersionForTask('-Prelease.tryUsingLastTag=true', 'build')
+
+        then:
+        version.toString().contains('42.6.0-dev.1+')
+    }
 
     def 'able to release with the override of version calculation'() {
         when:

--- a/src/main/groovy/nebula/plugin/release/OverrideStrategies.groovy
+++ b/src/main/groovy/nebula/plugin/release/OverrideStrategies.groovy
@@ -33,6 +33,32 @@ import org.slf4j.LoggerFactory
  */
 class OverrideStrategies {
 
+    static class TryReleaseLastTagStrategy implements VersionStrategy {
+        static final String PROPERTY_NAME = 'release.tryUsingLastTag'
+
+        @Override
+        String getName() {
+            return 'try-using-last-tag'
+        }
+
+        @Override
+        boolean selector(Project project, Grgit grgit) {
+            if (!(project.hasProperty(PROPERTY_NAME) && project.property(PROPERTY_NAME).toString().toBoolean())) {
+                return false
+            }
+            try {
+                new ReleaseLastTagStrategy(project).infer(project, grgit)
+            } catch (GradleException e) {
+                return false
+            }
+            return true
+        }
+
+        @Override
+        ReleaseVersion infer(Project project, Grgit grgit) {
+            return new ReleaseLastTagStrategy(project).infer(project, grgit)
+        }
+    }
 
     static class ReleaseLastTagStrategy implements VersionStrategy {
         static final String PROPERTY_NAME = 'release.useLastTag'

--- a/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
@@ -86,6 +86,7 @@ class ReleasePlugin implements Plugin<Project> {
             releaseExtension.with {
                 versionStrategy new OverrideStrategies.NoCommitStrategy()
                 versionStrategy new OverrideStrategies.ReleaseLastTagStrategy(project)
+                versionStrategy new OverrideStrategies.TryReleaseLastTagStrategy()
                 versionStrategy new OverrideStrategies.GradlePropertyStrategy(project)
                 versionStrategy NetflixOssStrategies.SNAPSHOT(project)
                 versionStrategy NetflixOssStrategies.IMMUTABLE_SNAPSHOT(project)


### PR DESCRIPTION
Fixes #84.

Suggestions for improvements, e.g. a better name for the flag, are more than welcome.

I have introduced a new flag rather than changing the behaviour of `-Prelease.useLastTag=true` in order to remain backwards compatible.

The use case is as follows: Suppose that in a CI pipeline you want to use the last tag when rebuilding this tag and otherwise fallback to the default strategy to determine the project version. Then you can simply add `release.tryUsingLastTag=true` to the gradle.properties file of your project. 