### PR TITLE
feat(performance): don’t force tasks to be created

### DIFF
--- a/src/main/groovy/nebula/plugin/release/git/base/BaseReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/base/BaseReleasePlugin.groovy
@@ -60,7 +60,7 @@ class BaseReleasePlugin implements Plugin<Project> {
             }
         }
 
-        project.tasks.all { task ->
+        project.tasks.configureEach { task ->
             if (name != PREPARE_TASK_NAME) {
                 task.shouldRunAfter PREPARE_TASK_NAME
             }

--- a/src/test/groovy/nebula/plugin/release/ReleasePluginConfigurationAvoidanceSpec.groovy
+++ b/src/test/groovy/nebula/plugin/release/ReleasePluginConfigurationAvoidanceSpec.groovy
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nebula.plugin.release
+
+import nebula.test.ProjectSpec
+import nebula.plugin.release.git.base.BaseReleasePlugin
+import nebula.plugin.release.git.base.ReleasePluginExtension
+
+class ReleasePluginConfigurationAvoidanceSpec extends ProjectSpec {
+    def 'able to configure tasks lazily'() {
+        setup:
+        project.tasks.register('sync') {
+            throw new Exception('Should not be configured')
+        }
+
+        when:
+        project.plugins.apply(BaseReleasePlugin)
+
+        then:
+        notThrown(Exception)
+    }
+}


### PR DESCRIPTION
I had a problem with running nebula-release alongside cognifide aem plugin. I wrote about this on the [discussion board](https://discuss.gradle.org/t/mediating-between-nebula-release-and-cognifide-aem-which-one-is-right/33954) but got no replies so far.

I switched the code that ensures the `prepare` task runs before all others to use the task configuration avoidance API [as described](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:old_vs_new_configuration_api_overview).

There are lots of other places where we should be conforming to best practices and use the task configuration avoidance rather than the explicit task API and I only fixed the code that forced the configurations of all tasks to be non-lazily evaluated. This should fix the bulk of the performance and other issues stemming from the use of the explicit task API.