### PR TITLE
Avoid configuring tasks

### DIFF
--- a/src/main/groovy/nebula/plugin/release/OverrideStrategies.groovy
+++ b/src/main/groovy/nebula/plugin/release/OverrideStrategies.groovy
@@ -57,7 +57,9 @@ class OverrideStrategies {
             def shouldSelect = project.hasProperty(propertyName) ? project.property(propertyName).toString().toBoolean() : false
 
             if (shouldSelect) {
-                project.tasks.getByName('release').enabled = false // remove tagging op since already tagged
+                project.tasks.named('release').configure {
+                    it.enabled = false // remove tagging op since already tagged
+                }
             }
 
             shouldSelect

--- a/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
@@ -39,6 +39,7 @@ import org.gradle.api.publish.ivy.tasks.GenerateIvyDescriptor
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.api.publish.maven.tasks.GenerateMavenPom
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
+import org.gradle.api.tasks.TaskProvider
 
 class ReleasePlugin implements Plugin<Project> {
     public static final String DISABLE_GIT_CHECKS = 'release.disableGitChecks'
@@ -120,51 +121,64 @@ class ReleasePlugin implements Plugin<Project> {
             ReleaseExtension nebulaReleaseExtension = project.extensions.create(NEBULA_RELEASE_EXTENSION_NAME, ReleaseExtension)
             NetflixOssStrategies.BuildMetadata.nebulaReleaseExtension = nebulaReleaseExtension
 
-            ReleaseCheck releaseCheck = project.tasks.create(RELEASE_CHECK_TASK_NAME, ReleaseCheck)
-            releaseCheck.group = GROUP
-            releaseCheck.branchName = releaseExtension.grgit.branch.current().name
-            releaseCheck.patterns = nebulaReleaseExtension
-
-            def postReleaseTask = project.task(POST_RELEASE_TASK_NAME)
-            postReleaseTask.group = GROUP
-            postReleaseTask.dependsOn project.tasks.getByName('release')
-
-            Task snapshotSetupTask = project.task(SNAPSHOT_SETUP_TASK_NAME)
-            Task immutableSnapshotSetupTask = project.task(IMMUTABLE_SNAPSHOT_SETUP_TASK_NAME)
-            Task devSnapshotSetupTask = project.task(DEV_SNAPSHOT_SETUP_TASK_NAME)
-            Task candidateSetupTask = project.task(CANDIDATE_SETUP_TASK_NAME)
-            candidateSetupTask.doLast {
-                project.allprojects.each { it.status = 'candidate' }
-            }
-            Task finalSetupTask = project.task(FINAL_SETUP_TASK_NAME)
-            finalSetupTask.doLast {
-                project.allprojects.each { it.status = 'release' }
-            }
-
-            [snapshotSetupTask, immutableSnapshotSetupTask, devSnapshotSetupTask, candidateSetupTask, finalSetupTask].each {
+            TaskProvider<ReleaseCheck> releaseCheck = project.tasks.register(RELEASE_CHECK_TASK_NAME, ReleaseCheck) {
                 it.group = GROUP
-                it.dependsOn releaseCheck
+                it.branchName = releaseExtension.grgit.branch.current().name
+                it.patterns = nebulaReleaseExtension
             }
 
-            Task snapshotTask = project.task(SNAPSHOT_TASK_NAME)
-            snapshotTask.dependsOn snapshotSetupTask
-            Task immutableSnapshotTask = project.task(IMMUTABLE_SNAPSHOT_TASK_NAME)
-            immutableSnapshotTask.dependsOn immutableSnapshotSetupTask
-            Task devSnapshotTask = project.task(DEV_SNAPSHOT_TASK_NAME)
-            devSnapshotTask.dependsOn devSnapshotSetupTask
-            Task candidateTask = project.task(CANDIDATE_TASK_NAME)
-            candidateTask.dependsOn candidateSetupTask
-            Task finalTask = project.task(FINAL_TASK_NAME)
-            finalTask.dependsOn finalSetupTask
+            TaskProvider<Task> postReleaseTask = project.tasks.register(POST_RELEASE_TASK_NAME) {
+                it.group = GROUP
+                it.dependsOn project.tasks.named('release')
+            }
+
+            TaskProvider snapshotSetupTask = project.tasks.register(SNAPSHOT_SETUP_TASK_NAME)
+            TaskProvider immutableSnapshotSetupTask = project.tasks.register(IMMUTABLE_SNAPSHOT_SETUP_TASK_NAME)
+            TaskProvider devSnapshotSetupTask = project.tasks.register(DEV_SNAPSHOT_SETUP_TASK_NAME)
+            TaskProvider candidateSetupTask = project.tasks.register(CANDIDATE_SETUP_TASK_NAME) {
+                it.doLast {
+                    project.allprojects.each { it.status = 'candidate' }
+                }
+            }
+            TaskProvider finalSetupTask = project.tasks.register(FINAL_SETUP_TASK_NAME) {
+                it.doLast {
+                    project.allprojects.each { it.status = 'release' }
+                }
+
+            }
+            [snapshotSetupTask, immutableSnapshotSetupTask, devSnapshotSetupTask, candidateSetupTask, finalSetupTask].each {
+                it.configure {
+                    it.group = GROUP
+                    it.dependsOn releaseCheck
+                }
+            }
+
+            TaskProvider<Task> snapshotTask = project.tasks.register(SNAPSHOT_TASK_NAME) {
+                it.dependsOn snapshotSetupTask
+            }
+            TaskProvider<Task> immutableSnapshotTask = project.tasks.register(IMMUTABLE_SNAPSHOT_TASK_NAME) {
+                it.dependsOn immutableSnapshotSetupTask
+            }
+            TaskProvider<Task> devSnapshotTask = project.tasks.register(DEV_SNAPSHOT_TASK_NAME) {
+                it.dependsOn devSnapshotSetupTask
+            }
+            TaskProvider<Task> candidateTask = project.tasks.register(CANDIDATE_TASK_NAME) {
+                it.dependsOn candidateSetupTask
+            }
+            TaskProvider<Task> finalTask = project.tasks.register(FINAL_TASK_NAME) {
+                it.dependsOn finalSetupTask
+            }
 
             [snapshotTask, immutableSnapshotTask, devSnapshotTask, candidateTask, finalTask].each {
-                it.group = GROUP
-                it.dependsOn postReleaseTask
+                it.configure {
+                    it.group = GROUP
+                    it.dependsOn postReleaseTask
+                }
             }
 
             List<String> cliTasks = project.gradle.startParameter.taskNames
-            determineStage(cliTasks, releaseCheck, replaceDevSnapshots)
-            checkStateForStage()
+            def isSnapshotRelease = determineStage(cliTasks, releaseCheck, replaceDevSnapshots)
+            checkStateForStage(isSnapshotRelease)
 
             if (shouldSkipGitChecks()) {
                 removeReleaseAndPrepLogic(project)
@@ -217,7 +231,7 @@ class ReleasePlugin implements Plugin<Project> {
         }
     }
 
-    private void determineStage(List<String> cliTasks, ReleaseCheck releaseCheck, boolean replaceDevSnapshots) {
+    private boolean determineStage(List<String> cliTasks, TaskProvider<ReleaseCheck> releaseCheck, boolean replaceDevSnapshots) {
         def hasSnapshot = cliTasks.contains(SNAPSHOT_TASK_NAME)
         def hasDevSnapshot = cliTasks.contains(DEV_SNAPSHOT_TASK_NAME)
         def hasImmutableSnapshot = cliTasks.contains(IMMUTABLE_SNAPSHOT_TASK_NAME)
@@ -227,7 +241,11 @@ class ReleasePlugin implements Plugin<Project> {
             throw new GradleException('Only one of snapshot, immutableSnapshot, devSnapshot, candidate, or final can be specified.')
         }
 
-        releaseCheck.isSnapshotRelease = hasSnapshot || hasDevSnapshot || (!hasCandidate && !hasFinal)
+        def isSnapshotRelease = hasSnapshot || hasDevSnapshot || (!hasCandidate && !hasFinal)
+
+        releaseCheck.configure {
+            it.isSnapshotRelease = isSnapshotRelease
+        }
 
         if (hasFinal) {
             setupStatus('release')
@@ -246,10 +264,12 @@ class ReleasePlugin implements Plugin<Project> {
                 applyReleaseStage('dev')
             }
         }
+
+        return isSnapshotRelease
     }
 
-    private void checkStateForStage() {
-        if (!(project.tasks.getByName('releaseCheck') as ReleaseCheck).isSnapshotRelease) {
+    private void checkStateForStage(boolean isSnapshotRelease) {
+        if (!isSnapshotRelease) {
             Status status = git.status()
             if (!status.isClean()) {
                 String message = new ErrorMessageFormatter().format(status)
@@ -364,7 +384,7 @@ class ReleasePlugin implements Plugin<Project> {
     }
 
     void checkForBadBranchNames() {
-        if (git.branch.current.name ==~ /release\/\d+(\.\d+)?/) {
+        if (git.branch.current().name ==~ /release\/\d+(\.\d+)?/) {
             throw new GradleException('Branches with pattern release/<version> are used to calculate versions. The version must be of form: <major>.x, <major>.<minor>.x, or <major>.<minor>.<patch>')
         }
     }

--- a/src/main/groovy/nebula/plugin/release/git/base/BaseReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/base/BaseReleasePlugin.groovy
@@ -61,7 +61,7 @@ class BaseReleasePlugin implements Plugin<Project> {
         }
 
         project.tasks.configureEach { task ->
-            if (name != PREPARE_TASK_NAME) {
+            if (task.name != PREPARE_TASK_NAME) {
                 task.shouldRunAfter PREPARE_TASK_NAME
             }
         }

--- a/src/main/groovy/nebula/plugin/release/git/base/BaseReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/base/BaseReleasePlugin.groovy
@@ -52,10 +52,10 @@ class BaseReleasePlugin implements Plugin<Project> {
     }
 
     private void addPrepareTask(Project project, ReleasePluginExtension extension) {
-        project.tasks.create(PREPARE_TASK_NAME) {
-            description = 'Verifies that the project could be released.'
-            doLast {
-                ext.grgit = extension.grgit
+        project.tasks.register(PREPARE_TASK_NAME) {
+            it.description = 'Verifies that the project could be released.'
+            it.doLast {
+                project.ext.grgit = extension.grgit
                 prepare(extension)
             }
         }
@@ -69,11 +69,11 @@ class BaseReleasePlugin implements Plugin<Project> {
 
 
     private void addReleaseTask(Project project, ReleasePluginExtension extension) {
-        project.tasks.create(RELEASE_TASK_NAME) {
-            description = 'Releases this project.'
-            dependsOn PREPARE_TASK_NAME
-            doLast {
-                release(project, ext, extension)
+        project.tasks.register(RELEASE_TASK_NAME) {
+            it.description = 'Releases this project.'
+            it.dependsOn PREPARE_TASK_NAME
+            it.doLast {
+                release(project, project.ext, extension)
             }
         }
     }

--- a/src/main/groovy/nebula/plugin/release/git/experimental/ExperimentalReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/experimental/ExperimentalReleasePlugin.groovy
@@ -53,8 +53,8 @@ class ExperimentalReleasePlugin implements Plugin<Project> {
             }
         }
 
-        project.tasks.all { task ->
-            if (name != PREPARE_TASK_NAME) {
+        project.tasks.configureEach { task ->
+            if (task.name != PREPARE_TASK_NAME) {
                 task.shouldRunAfter PREPARE_TASK_NAME
             }
         }


### PR DESCRIPTION
As promised in #172, I tried to replace more usages of the old explicit task API with the [task avoidance best practices](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:old_vs_new_configuration_api_overview).

The tests all run through but I’m not sure I didn’t break anything. Also I didn’t add a new test as I wasn’t really sure what to test for…