### PR TITLE
ReleasePlugin.checkForBadBranchNames should fail if branch ends with dash

### DIFF
--- a/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
@@ -21,6 +21,7 @@ import nebula.plugin.release.git.base.ReleasePluginExtension
 import nebula.plugin.release.git.base.ReleaseVersion
 import nebula.plugin.release.git.base.TagStrategy
 import nebula.plugin.release.git.semver.SemVerStrategy
+import org.ajoberstar.grgit.Branch
 import org.ajoberstar.grgit.Commit
 import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.Status
@@ -387,7 +388,11 @@ class ReleasePlugin implements Plugin<Project> {
     }
 
     void checkForBadBranchNames() {
-        if (git.branch.current().name ==~ /release\/\d+(\.\d+)?/) {
+        Branch currentBranch = git.branch.current()
+        if(currentBranch.name.endsWith('-')) {
+            throw new GradleException('Nebula Release plugin does not support branches that end with dash (-)')
+        }
+        if (currentBranch.name ==~ /release\/\d+(\.\d+)?/) {
             throw new GradleException('Branches with pattern release/<version> are used to calculate versions. The version must be of form: <major>.x, <major>.<minor>.x, or <major>.<minor>.<patch>')
         }
     }


### PR DESCRIPTION
This is to prevent issues like:

```
> Failed to apply plugin ['']
   > Could not resolve all dependencies for configuration ':mytask'.
      > Identifiers MUST NOT be empty

Caused by: Identifiers MUST NOT be empty (Unexpected character 'DOT(.)' at position '24', expecting '[DIGIT, LETTER, HYPHEN]')
        at com.github.zafarkhaja.semver.VersionParser.checkForEmptyIdentifier(VersionParser.java:498)
        at com.github.zafarkhaja.semver.VersionParser.buildIdentifier(VersionParser.java:384)
        at com.github.zafarkhaja.semver.VersionParser.parseBuild(VersionParser.java:361)
        at com.github.zafarkhaja.semver.VersionParser.parseValidSemVer(VersionParser.java:264)
        at com.github.zafarkhaja.semver.VersionParser.parseValidSemVer(VersionParser.java:195)
        at com.github.zafarkhaja.semver.Version$Builder.build(Version.java:158)
        at sun.reflect.GeneratedMethodAccessor1041.invoke(Unknown Source)
```