### PR TITLE
Using a non-semver version for release.version should fail

### DIFF
--- a/src/test/groovy/nebula/plugin/release/OverrideStrategiesSpec.groovy
+++ b/src/test/groovy/nebula/plugin/release/OverrideStrategiesSpec.groovy
@@ -37,7 +37,7 @@ class OverrideStrategiesSpec extends ProjectSpec {
 
     def 'able to set via gradle property and sanitize'() {
         setup:
-        project.ext.set('release.version', '42.5.0+feature')
+        project.ext.set('release.version', '42.5.0-rc.1+feature')
         project.ext.set('release.sanitizeVersion', true)
 
         when:
@@ -48,6 +48,6 @@ class OverrideStrategiesSpec extends ProjectSpec {
         }
 
         then:
-        project.version.toString() == '42.5.0.feature'
+        project.version.toString() == '42.5.0-rc.1.feature'
     }
 }


### PR DESCRIPTION
In order to keep consistency with version calculation, the plugin should fail with non-semver versions

`ignoreSuppliedVersionVerification` flag is available when desired to bypass this