### PR TITLE
Avoid git status call for strategy selection unless required

### DIFF
--- a/src/main/groovy/nebula/plugin/release/git/semver/SemVerStrategy.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/semver/SemVerStrategy.groovy
@@ -131,8 +131,7 @@ final class SemVerStrategy implements DefaultVersionStrategy {
             logger.info('Skipping {} strategy because repo is dirty.', name)
             return false
         } else {
-            String status = grgit.status().clean ? 'clean' : 'dirty'
-            logger.info('Using {} strategy because repo is {} and stage ({}) is one of: {}', name, status, stage, stages)
+            logger.info('Using {} strategy because repo is not dirty (or allowed to be dirty) and stage ({}) is one of: {}', name, stage, stages)
             return true
         }
     }


### PR DESCRIPTION
Git status can be really slow on repositories with deep history.

I wonder if we could use an alternative for checking dirty?

https://stackoverflow.com/a/2658301/364206

For instance on `gradle/gradle`:

```
git status --porcelain  0.12s user 0.40s system 154% cpu 0.342 total
git diff --shortstat  0.08s user 0.21s system 304% cpu 0.093 total
```

Looking at `StatusCommand` it appears it's just doing a diff anyway. This looks even better:

```
git diff-index --quiet HEAD  0.03s user 0.19s system 618% cpu 0.035 total
```

But it looks like those alternatives only catch changed files, not new files not in the index.