### PR TITLE
nebula.release should not enforce precedence for immutable snapshots

### DIFF
--- a/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
@@ -1252,6 +1252,31 @@ class ReleasePluginIntegrationSpec extends GitVersioningIntegrationSpec {
         result.standardOutput.contains('Pushing changes in [v0.1.0] to origin')
     }
 
+    def 'Can create devSnapshot with scope patch if candidate for next minor is present'() {
+        git.tag.add(name: 'v3.1.2')
+        git.tag.add(name: 'v3.2.0-rc.1')
+        git.tag.add(name: 'v3.2.0-rc.2')
+
+        when:
+        def version =  inferredVersionForTask('devSnapshot', '-Prelease.scope=patch')
+
+        then:
+        version == dev('3.1.3-dev.0+')
+    }
+
+    def 'Can create devSnapshot with scope patch if candidate for next minor is present - immutable snapshot'() {
+        replaceDevWithImmutableSnapshot()
+        git.tag.add(name: 'v3.1.2')
+        git.tag.add(name: 'v3.2.0-rc.1')
+        git.tag.add(name: 'v3.2.0-rc.2')
+
+        when:
+        def version =  inferredVersionForTask('devSnapshot', '-Prelease.scope=patch')
+
+        then:
+        version.toString().startsWith("3.1.3-snapshot." + getUtcDateForComparison())
+    }
+
     private void replaceDevWithImmutableSnapshot() {
         new File(buildFile.parentFile, "gradle.properties").text = """
 nebula.release.features.replaceDevWithImmutableSnapshot=true

--- a/src/main/groovy/nebula/plugin/release/git/opinion/Strategies.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/opinion/Strategies.groovy
@@ -343,7 +343,8 @@ final class Strategies {
             allowDirtyRepo: true,
             preReleaseStrategy: all(PreRelease.STAGE_FLOAT, PreRelease.TIMESTAMP, PreRelease.SHOW_UNCOMMITTED),
             buildMetadataStrategy: BuildMetadata.COMMIT_ABBREVIATED_ID,
-            createTag: false
+            createTag: false,
+            enforcePrecedence: false
     )
 
     /**


### PR DESCRIPTION
This fixes https://github.com/nebula-plugins/nebula-release-plugin/issues/199
We found that 

```
git.tag.add(name: 'v3.1.2')
git.tag.add(name: 'v3.2.0-rc.1')
git.tag.add(name: 'v3.2.0-rc.2')

when:
def version =  inferredVersionForTask('devSnapshot', '-Prelease.scope=patch')

then:
version == dev('3.1.3-dev.0+') 
 ```

However, doing this with immutable snapshots:

```
replaceDevWithImmutableSnapshot()
git.tag.add(name: 'v3.1.2')
git.tag.add(name: 'v3.2.0-rc.1')
git.tag.add(name: 'v3.2.0-rc.2')

when:
def version =  inferredVersionForTask('devSnapshot', '-Prelease.scope=patch')

then:
version.toString().startsWith("3.1.3-snapshot." + getUtcDateForComparison()) 
```

results in exceptions such as 

```
11:49:17 Caused by: org.gradle.api.GradleException: Based on previous tags in this branch the nearest version is 70.4.0-rc.15 You're attempting to release 70.3.1-snapshot.202009231549+pull.545.9c0f663 based on the tag recently pushed. Please look at https://github.com/nebula-plugins/nebula-release-plugin/wiki/Error-Messages-Explained#orggradleapigradleexception-inferred-version-cannot-be-lower-than-nearest-required-by-selected-strategy 
```

We should have the same behavior as in `dev` suffix