### PR TITLE
Relative directory support for git.root in java 1.14 #204

### DIFF
--- a/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
@@ -74,7 +74,7 @@ class ReleasePlugin implements Plugin<Project> {
     void apply(Project project) {
         this.project = project
 
-        def gitRoot = project.hasProperty('git.root') ? project.property('git.root') : project.rootProject.projectDir
+        def gitRoot = project.hasProperty('git.root') ? project.file(project.property('git.root')) : project.rootProject.projectDir
 
         try {
             git = Grgit.open(dir: gitRoot)


### PR DESCRIPTION
Fix for #204 

In newer versions of java than 1.8 Grgit.open is done relative to the
daemon home instead of the project home.  Using project.file on the
git.root parameter if it exists fixes this.  See example project:
See https://github.com/shysteph/nebula-release-plugin-bug