### PR TITLE
Resolved #221 corrects  release notes

### DIFF
--- a/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
@@ -111,7 +111,7 @@ class ReleasePlugin implements Plugin<Project> {
                         builder << "Release of ${version.version}\n\n"
 
                         if (version.previousVersion) {
-                            String previousVersion = "v${version.previousVersion}^{commit}"
+                            String previousVersion = "${project.release.tagStrategy.toTagString(version.previousVersion)}^{commit}"
                             List excludes = []
                             if (tagExists(grgit, previousVersion)) {
                                 excludes << previousVersion


### PR DESCRIPTION
Release notes when prefixNameWithV==false is corrected by finding the previous tag