### PR TITLE
Upgrade grgit-core to 4.1.1 (fixes #229)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ compileGroovy.groovyOptions.configurationScript = file('src/groovyCompile/groovy
 
 dependencies {
     implementation 'org.eclipse.jgit:org.eclipse.jgit:5.7.0.202003110725-r'
-    implementation ('org.ajoberstar.grgit:grgit-core:4.0.2') {
+    implementation ('org.ajoberstar.grgit:grgit-core:4.1.1') {
         exclude group: 'org.codehaus.groovy', module: 'groovy'
     }
     implementation 'com.github.zafarkhaja:java-semver:0.9.0'


### PR DESCRIPTION
4.0.2 is not available on Maven Central, with the available versions being 4.1.1 and 5.0.0. This updates to the closest version assuming semver.