### PR TITLE
Refactor NearestVersionLocator to reduce the number of native git calls

### DIFF
--- a/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/release/ReleasePluginIntegrationSpec.groovy
@@ -329,36 +329,6 @@ class ReleasePluginIntegrationSpec extends GitVersioningIntegrationTestKitSpec {
         version.toString().startsWith("1.0.0-snapshot." + getUtcDateForComparison())
     }
 
-    def 'allow create final from a commit when some of its candidates are before the commit'() {
-        given:
-        def file = new File(projectDir, "test_file.txt")
-        file.text = "DUMMY"
-        git.add(patterns: ['.'] as Set)
-        git.commit(message: "Add file")
-        git.push(all: true)
-        runTasks('candidate')
-        git.branch.add(name: "0.1.x")
-        file.text = "Updated dummy"
-        git.add(patterns: ['.'] as Set)
-        git.commit(message: "Update file")
-        git.push(all: true)
-        runTasks('candidate')
-
-        when:
-        git.checkout(branch: '0.1.x')
-        def version = inferredVersionForTask('final')
-
-        then:
-        version.toString() == normal('0.1.0').toString()
-
-        when:
-        git.checkout(branch: 'master')
-        version = inferredVersionForTask('candidate')
-
-        then:
-        version.toString() == normal('0.2.0-rc.1').toString()
-    }
-
     def 'create new major release branch in git-flow style and have branch name respected on version'() {
         def oneX = 'release/1.x'
         git.branch.add(name: oneX)

--- a/src/main/groovy/nebula/plugin/release/git/command/GitCommandParameters.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/command/GitCommandParameters.groovy
@@ -5,8 +5,8 @@ import org.gradle.api.provider.ValueSourceParameters
 
 interface GitCommandParameters extends ValueSourceParameters {
     Property<File> getRootDir()
-    Property<String> getTagForSearch()
     Property<String> getGitConfigScope()
     Property<String> getGitConfigKey()
     Property<String> getGitConfigValue()
+    Property<String> getCommit()
 }

--- a/src/main/groovy/nebula/plugin/release/git/command/GitReadCommand.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/command/GitReadCommand.groovy
@@ -58,11 +58,25 @@ abstract class CurrentBranch extends GitReadCommand {
  * Uses git describe to find a given tag in the history of the current branch
  * ex. git describe HEAD --tags --match v10.0.0 -> v10.0.0-220-ga00baaa
  */
-abstract class DescribeTagForHead extends GitReadCommand {
+abstract class DescribeHeadWithTag extends GitReadCommand {
     @Override
     String obtain() {
         try {
-            return executeGitCommand( "describe", "HEAD", "--tags", "--match", parameters.getTagForSearch().get())
+            return executeGitCommand( "describe", "HEAD", "--tags", "--long")
+        } catch (Exception e) {
+            return null
+        }
+    }
+}
+/**
+ * Uses git describe to find a given tag in the history of the current branch
+ * ex. git describe HEAD --tags --match v10.0.0 -> v10.0.0-220-ga00baaa
+ */
+abstract class TagsPointingAt extends GitReadCommand {
+    @Override
+    String obtain() {
+        try {
+            return executeGitCommand( "tag", "--points-at", parameters.commit.get())
         } catch (Exception e) {
             return null
         }

--- a/src/main/groovy/nebula/plugin/release/git/command/GitReadOnlyCommandUtil.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/command/GitReadOnlyCommandUtil.groovy
@@ -120,19 +120,6 @@ class GitReadOnlyCommandUtil implements Serializable {
                 .collect { new TagRef(it) }
     }
 
-    /**
-     * Returns the tags that point to the current HEAD
-     */
-    List<String> refTags() {
-        try {
-            return refTagsProvider.get().toString()
-                    .split("\n")
-                    .findAll { String tag -> !tag?.replaceAll("\n", "")?.isEmpty() }
-                    .toList()
-        } catch (Exception e) {
-            return Collections.emptyList()
-        }
-    }
 
     Integer getCommitCountForHead() {
         try {
@@ -144,15 +131,29 @@ class GitReadOnlyCommandUtil implements Serializable {
         }
     }
 
-    String describeTagForHead(String tagName) {
+    String describeHeadWithTags() {
         try {
-            def describeTagInHeadProvider = providers.of(DescribeTagForHead.class) {
+            def describeTagInHeadProvider = providers.of(DescribeHeadWithTag.class) {
                 it.parameters.rootDir.set(rootDir)
-                it.parameters.tagForSearch.set(tagName)
             }
             return describeTagInHeadProvider.get().toString()
                     .split("\n")
                     .first()?.replaceAll("\n", "")?.toString()
+        } catch(Exception e) {
+            return null
+        }
+    }
+
+    List<String> getTagsPointingAt(String commit) {
+        try {
+            def tagsPointingAtProvider = providers.of(TagsPointingAt.class) {
+                it.parameters.rootDir.set(rootDir)
+                it.parameters.commit.set(commit)
+            }
+            return tagsPointingAtProvider.get().toString()
+                    .split("\n")
+                    .findAll { String tag -> !tag?.replaceAll("\n", "")?.isEmpty() }
+                    .collect()
         } catch(Exception e) {
             return null
         }

--- a/src/main/groovy/nebula/plugin/release/git/command/GitWriteCommandsUtil.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/command/GitWriteCommandsUtil.groovy
@@ -81,10 +81,6 @@ class GitWriteCommandsUtil implements Serializable {
             it.standardOutput = output
             it.errorOutput = error
         }
-        def errorMsg = new String(error.toByteArray(), Charset.defaultCharset())
-        if(errorMsg) {
-            throw new GradleException(errorMsg)
-        }
         return new String(output.toByteArray(), Charset.defaultCharset())
     }
 }


### PR DESCRIPTION
The initial refactor to use native git introduced a big performance hit:

```
2023-11-08T16:37:04.041-0800 [DEBUG] [nebula.plugin.release.git.semver.NearestVersionLocator] Locate beginning on branch: testing
2023-11-08T16:37:56.318-0800 [DEBUG] [nebula.plugin.release.git.semver.NearestVersionLocator] Nearest release: {version=9.5.0, distance=73}, nearest any: {version=10.0.0-rc.1, distance=1}.
```

Historically, we have iterated over all tags and sort them by distance in order to determine which one is closer. Unfortunately, when doing git native calls, it is way less performant that in memory git representation with jgit. This change to native git contributed to ~50s of configuration time for a project that has ~1.2k tags 

After looking into the actual purpose and even description of the method (`The nearest tag is determined by getting a commit log between the tag and {@code HEAD}`), I found that really we could use less commands to get this information.

This change is to move away from looping through all the tags and instead do the following:

* `git describe HEAD --tags --long` which finds the most recent tag that is reachable from a commit and it gives back the `<tag>-<distance>-g<commithash>` 
* Now that we have the the last known commit with a tag, we do `git tag --points-at <commit>` which basically returns all the tags associated to the commit. This is done this common scenarios of multiple tags for the same commit and from there we just sort that small list instead of parsing and sorting **all** the tags in the repository

