### PR TITLE
Fix git.root failing git repo detection: Set rootDir as working dir for git execs

### DIFF
--- a/src/main/groovy/nebula/plugin/release/git/command/GitReadCommand.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/command/GitReadCommand.groovy
@@ -26,6 +26,7 @@ abstract class GitReadCommand implements ValueSource<String, GitCommandParameter
         List<String> commandLineArgs = ["git", "--git-dir=${rootDir.absolutePath}/.git".toString(), "--work-tree=${rootDir.absolutePath}".toString()]
         commandLineArgs.addAll(args)
         execOperations.exec {
+            it.setWorkingDir(rootDir.absolutePath)
             it.setCommandLine(commandLineArgs)
             it.standardOutput = output
             it.errorOutput = error
@@ -45,6 +46,7 @@ abstract class GitReadCommand implements ValueSource<String, GitCommandParameter
         List<String> commandLineArgs = ["git", "--git-dir=${rootDir.absolutePath}/.git".toString(), "--work-tree=${rootDir.absolutePath}".toString()]
         commandLineArgs.addAll(args)
         execOperations.exec {
+            it.setWorkingDir(rootDir.absolutePath)
             it.setCommandLine(commandLineArgs)
             it.standardOutput = output
             it.errorOutput = error

--- a/src/main/groovy/nebula/plugin/release/git/command/GitWriteCommandsUtil.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/command/GitWriteCommandsUtil.groovy
@@ -76,6 +76,7 @@ class GitWriteCommandsUtil implements Serializable {
         List<String> commandLineArgs = ["git", "--git-dir=${rootDir.absolutePath}/.git".toString(), "--work-tree=${rootDir.absolutePath}".toString()]
         commandLineArgs.addAll(args)
         execOperations.exec {
+            it.setWorkingDir(rootDir.absolutePath)
             it.ignoreExitValue = true
             it.setCommandLine(commandLineArgs)
             it.standardOutput = output


### PR DESCRIPTION
Setting the Gradle git.root property as per the docs (https://github.com/nebula-plugins/nebula-release-plugin#git-root-is-in-a-different-location-from-gradle-root) fails since major release 18+.

The command "rev-parse --is-inside-work-tree" returns false and makes the plugin fail to detect the git repo.

Some debugging on my part revealed the culprit being the git command working directory still being the Gradle projectDir causes this behavior. Setting the working directory for the git exec command to the provided git.root directory solves the failing detection.