### PR TITLE
Only verify git user information when creating and pushing tags. 

### DIFF
--- a/src/main/groovy/nebula/plugin/release/OverrideStrategies.groovy
+++ b/src/main/groovy/nebula/plugin/release/OverrideStrategies.groovy
@@ -25,6 +25,7 @@ import nebula.plugin.release.git.command.GitReadOnlyCommandUtil
 import nebula.plugin.release.git.model.TagRef
 import nebula.plugin.release.git.opinion.TimestampUtil
 import nebula.plugin.release.git.semver.NearestVersionLocator
+import nebula.plugin.release.util.ReleaseTasksUtil
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.slf4j.Logger
@@ -37,14 +38,13 @@ class OverrideStrategies {
 
 
     static class ReleaseLastTagStrategy implements VersionStrategy {
-        static final String PROPERTY_NAME = 'release.useLastTag'
         private static final String NOT_SUPPLIED = 'release-strategy-is-not-supplied'
         private static final Logger logger = LoggerFactory.getLogger(ReleaseLastTagStrategy)
 
         Project project
         String propertyName
 
-        ReleaseLastTagStrategy(Project project, String propertyName = PROPERTY_NAME) {
+        ReleaseLastTagStrategy(Project project, String propertyName = ReleaseTasksUtil.USE_LAST_TAG_PROPERTY) {
             this.project = project
             this.propertyName = propertyName
         }

--- a/src/main/groovy/nebula/plugin/release/git/command/GitReadOnlyCommandUtil.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/command/GitReadOnlyCommandUtil.groovy
@@ -34,7 +34,7 @@ class GitReadOnlyCommandUtil implements Serializable {
      * This uses the provider factory to create the providers in order to support ocnfiguration cache
      * @param gitRoot
      */
-    void configure(File gitRoot) {
+    void configure(File gitRoot, boolean shouldVerifyUserGitConfig) {
         this.rootDir = gitRoot
         usernameFromLogProvider = providers.of(UsernameFromLog.class) {
             it.parameters.rootDir.set(rootDir)
@@ -42,7 +42,9 @@ class GitReadOnlyCommandUtil implements Serializable {
         emailFromLogProvider = providers.of(EmailFromLog.class) {
             it.parameters.rootDir.set(rootDir)
         }
-        verifyGitConfig()
+        if(shouldVerifyUserGitConfig) {
+            verifyUserGitConfig()
+        }
         currentBranchProvider = providers.of(CurrentBranch.class) {
             it.parameters.rootDir.set(rootDir)
         }
@@ -76,7 +78,7 @@ class GitReadOnlyCommandUtil implements Serializable {
 
     }
 
-    private void verifyGitConfig() {
+    private void verifyUserGitConfig() {
         String username = getGitConfig('user.name')
         String email = getGitConfig('user.email')
         String globalUsername = getGitConfig('--global', 'user.name')
@@ -250,7 +252,9 @@ class GitReadOnlyCommandUtil implements Serializable {
             logger.debug("Could not get git config {} {} {}", scope, configKey)
             return null
         }
-    }    /**
+    }
+
+    /**
      * Returns a git config value for a given scope
      * @param configKey
      * @return

--- a/src/main/groovy/nebula/plugin/release/util/ReleaseTasksUtil.groovy
+++ b/src/main/groovy/nebula/plugin/release/util/ReleaseTasksUtil.groovy
@@ -1,0 +1,37 @@
+package nebula.plugin.release.util
+
+import org.gradle.api.Project
+
+class ReleaseTasksUtil {
+
+    static final String SNAPSHOT_TASK_NAME = 'snapshot'
+    static final String SNAPSHOT_TASK_NAME_OPTIONAL_COLON = ":$SNAPSHOT_TASK_NAME"
+    static final String SNAPSHOT_SETUP_TASK_NAME = 'snapshotSetup'
+    static final String DEV_SNAPSHOT_TASK_NAME = 'devSnapshot'
+    static final String DEV_SNAPSHOT_SETUP_TASK_NAME = 'devSnapshotSetup'
+    static final String DEV_SNAPSHOT_TASK_NAME_OPTIONAL_COLON = ":$DEV_SNAPSHOT_TASK_NAME"
+    static final String DEV_SNAPSHOT_SETUP_TASK_NAME_OPTIONAL_COLON = ":$DEV_SNAPSHOT_SETUP_TASK_NAME"
+    static final String IMMUTABLE_SNAPSHOT_TASK_NAME = 'immutableSnapshot'
+    static final String IMMUTABLE_SNAPSHOT_SETUP_TASK_NAME = 'immutableSnapshotSetup'
+    static final String IMMUTABLE_SNAPSHOT_TASK_NAME_OPTIONAL_COLON = ":$IMMUTABLE_SNAPSHOT_TASK_NAME"
+    static final String CANDIDATE_TASK_NAME = 'candidate'
+    static final String CANDIDATE_TASK_NAME_OPTIONAL_COLON = ":$CANDIDATE_TASK_NAME"
+    static final String CANDIDATE_SETUP_TASK_NAME = 'candidateSetup'
+    static final String FINAL_TASK_NAME = 'final'
+    static final String FINAL_TASK_NAME_WITH_OPTIONAL_COLON = ":$FINAL_TASK_NAME"
+    static final String FINAL_SETUP_TASK_NAME = 'finalSetup'
+    static final String RELEASE_CHECK_TASK_NAME = 'releaseCheck'
+    static final String NEBULA_RELEASE_EXTENSION_NAME = 'nebulaRelease'
+    static final String POST_RELEASE_TASK_NAME = 'postRelease'
+    static final String USE_LAST_TAG_PROPERTY = 'release.useLastTag'
+
+    static boolean isUsingLatestTag(Project project) {
+       return project.hasProperty(USE_LAST_TAG_PROPERTY) && project.property(USE_LAST_TAG_PROPERTY).toString().toBoolean()
+    }
+
+    static boolean isReleaseTaskThatRequiresTagging(List<String> cliTasks) {
+        def hasCandidate = cliTasks.contains(CANDIDATE_TASK_NAME) || cliTasks.contains(CANDIDATE_TASK_NAME_OPTIONAL_COLON)
+        def hasFinal = cliTasks.contains(FINAL_TASK_NAME) || cliTasks.contains(FINAL_TASK_NAME_WITH_OPTIONAL_COLON)
+        return hasCandidate || hasFinal
+    }
+}

--- a/src/test/groovy/nebula/plugin/release/util/ReleaseTasksUtilSpec.groovy
+++ b/src/test/groovy/nebula/plugin/release/util/ReleaseTasksUtilSpec.groovy
@@ -1,0 +1,52 @@
+package nebula.plugin.release.util
+
+import nebula.test.ProjectSpec
+import spock.lang.Unroll
+
+class ReleaseTasksUtilSpec extends ProjectSpec {
+
+    def 'verify isUsingLatestTag reads the project property accordingly'() {
+        given:
+        project
+
+        expect:
+        !ReleaseTasksUtil.isUsingLatestTag(project)
+
+        when:
+        project.ext.'release.useLastTag' = false
+
+        then:
+        !ReleaseTasksUtil.isUsingLatestTag(project)
+
+        when:
+        project.ext.'release.useLastTag' = true
+
+        then:
+        ReleaseTasksUtil.isUsingLatestTag(project)
+    }
+
+    @Unroll
+    def 'checking release task for #tasks results in #expected'() {
+        expect:
+        ReleaseTasksUtil.isReleaseTaskThatRequiresTagging(tasks) == expected
+
+        where:
+        tasks                          || expected
+        ['build']                      || false
+        ['build', 'devSnapshot']       || false
+        ['build', 'candidate']         || true
+        ['build', 'immutableSnapshot'] || false
+        ['build', 'final']             || true
+        [':devSnapshot']               || false
+        ['devSnapshot']                || false
+        [':snapshot']                  || false
+        ['snapshot']                   || false
+        ['candidate']                  || true
+        [':candidate']                 || true
+        ['immutableSnapshot']          || false
+        [':immutableSnapshot']         || false
+        ['final']                      || true
+        [':final']                     || true
+    }
+
+}


### PR DESCRIPTION
We probably should require git user information only when creating and pushing tags so that only applies to `candidate` and `final` tasks when `release.useLastTag` is not used.