### PR TITLE
Throw exception if tag can't be pushed

### DIFF
--- a/src/main/groovy/nebula/plugin/release/git/command/GitWriteCommandsUtil.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/command/GitWriteCommandsUtil.groovy
@@ -41,7 +41,7 @@ class GitWriteCommandsUtil implements Serializable {
             if(e.message.contains("* [new tag]")){
                 return
             }
-            logger.error("Failed to push tag ${tag} to remote ${remote}", e)
+            throw new RuntimeException("Failed to push tag ${tag} to remote ${remote}", e)
         }
     }
 


### PR DESCRIPTION
happening on version 19.0.6

## Current behaviour
If the push of the release tag fails, the build continues uninterrupted.

## Expected behaviour
If the push of the release tag fails, the build fails. 

## Impact
if the build fails to push the tag v1.1.0, the successive build will infer v1.1.0 again and will try to publish new artifacts with the same version of what was already published. This may cause replacement of previously published artifacts.


logs using `id("nebula.release") version "19.0.6"`
```
 > Task :release
 Caching disabled for task ':release' because:
   Build cache is disabled
 Task ':release' is not up-to-date because:
   Task has not declared any outputs despite executing actions.
 Tagging repository as v1.1.0
 Starting process 'command 'git''. Working directory: /some-path/code Command: git --git-dir=/some-path/code/.git --work-tree=/some-path/code tag -a v1.1.0 -m Release of 1.1.0


 Successfully started process 'command 'git''
 Pushing changes in v1.1.0 to origin
 Starting process 'command 'git''. Working directory: /some-path/code Command: git --git-dir=/some-path/code/.git --work-tree=/some-path/code push origin v1.1.0
 Successfully started process 'command 'git''
 Failed to push tag v1.1.0 to remote origin
 org.gradle.api.GradleException: fatal: could not read Username for 'some-repo': No such device or address
 
 	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
 	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
 	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
 	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
 	at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:72)
 	at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrapNoCoerce.callConstructor(ConstructorSite.java:105)
 	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:59)
 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:263)
 	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:277)
	at org.gradle.internal.classpath.Instrumented$FileInputStreamConstructorCallSite.callConstructor(Instrumented.java:971)
 	at nebula.plugin.release.git.command.GitWriteCommandsUtil.executeGitCommand(GitWriteCommandsUtil.groovy:89)
 	at nebula.plugin.release.git.command.GitWriteCommandsUtil.pushTag(GitWriteCommandsUtil.groovy:39)
 	at nebula.plugin.release.git.base.ReleaseTask.release(ReleaseTask.groovy:35)
        [...]

[...]
 BUILD SUCCESSFUL in 3m 14s
 46 actionable tasks: 46 executed
```