### PR TITLE
Support relative paths in `git.root`

### DIFF
--- a/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/ReleasePlugin.groovy
@@ -57,7 +57,7 @@ class ReleasePlugin implements Plugin<Project> {
     @CompileDynamic
     @Inject
     ReleasePlugin(Project project, ExecOperations execOperations, ProviderFactory providerFactory) {
-        this.gitRoot = project.hasProperty('git.root') ? new File(project.property('git.root')) : project.rootProject.projectDir
+        this.gitRoot = project.hasProperty('git.root') ? project.file(project.property('git.root')) : project.rootProject.projectDir
         this.gitBuildService = project.getGradle().getSharedServices().registerIfAbsent("gitBuildService", GitBuildService.class, spec -> {
             spec.getParameters().getGitRootDir().set(gitRoot)
         }).get()

--- a/src/main/groovy/nebula/plugin/release/git/base/BaseReleasePlugin.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/base/BaseReleasePlugin.groovy
@@ -41,7 +41,7 @@ class BaseReleasePlugin implements Plugin<Project> {
 
     void apply(Project project) {
         ReleasePluginExtension releasePluginExtension = project.extensions.create('release', ReleasePluginExtension, project)
-        File gitRoot = project.hasProperty('git.root') ? new File(project.property('git.root')) : project.rootProject.projectDir
+        File gitRoot = project.hasProperty('git.root') ? project.file(project.property('git.root')) : project.rootProject.projectDir
         this.gitBuildService = project.getGradle().getSharedServices().registerIfAbsent("gitBuildService", GitBuildService.class, spec -> {
             spec.getParameters().getGitRootDir().set(gitRoot)
         })

--- a/src/main/groovy/nebula/plugin/release/git/base/ReleasePluginExtension.groovy
+++ b/src/main/groovy/nebula/plugin/release/git/base/ReleasePluginExtension.groovy
@@ -67,7 +67,7 @@ class ReleasePluginExtension {
     @CompileDynamic
     @Inject
     ReleasePluginExtension(Project project) {
-        File gitRoot = project.hasProperty('git.root') ? new File(project.property('git.root')) : project.rootProject.projectDir
+        File gitRoot = project.hasProperty('git.root') ? project.file(project.property('git.root')) : project.rootProject.projectDir
         this.project = project
         this.gitBuildService = project.getGradle().getSharedServices().registerIfAbsent("gitBuildService", GitBuildService.class, spec -> {
             spec.getParameters().getGitRootDir().set(gitRoot)


### PR DESCRIPTION
Hi folks!

This adds support for relative paths in `git.root` in a way that seems recommended from [Gradle's docs](https://docs.gradle.org/current/userguide/working_with_files.html#sec:single_file_paths).

From a quick glance at the implementation it looks like this could be converted to use `providerFactory.gradleProperty('git.root')` with a convention and mapping to a file instance. I didn't take this step because it's a larger change.

### Additional Context

I have a project that attempts to set `git.root=..` in a nested directory. It looks like this:
```
rootDir
    my-gradle-project
        build.gradle
        settings.gradle
        gradle.properties
    other-project
```

I recently started getting a failure during Gradle's configuration phase that `..` must be an absolute path, demonstrated by the included test.